### PR TITLE
Quarks-240 [gradle] release task: manifest classpath, external deps, java7, android

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -113,7 +113,7 @@ maintain the build success of `clean, assemble, test, reports`.**
 The Gradle wrapper `edgent/{gradlew,gradlew.bat}` should be used to ensure an appropriate
 version of Gradle is used.  e.g.  `$ ./gradlew clean build`
 
-The top-level Gradle file is `edgent/build.gradle` and contains several
+The top-level Gradle file is `edgent/build.gradle` and it contains several
 unique tasks: 
 
 * `assemble` (default) : Build all code and Javadoc into `build\distributions`. The build will fail on any code error or Javadoc warning or error.
@@ -121,10 +121,12 @@ unique tasks:
 * `build` : essentially like "assemble test reports"
 * `clean` : Clean the project
 * `test` : Run the JUnit tests, if any test fails the test run stops.
-  * use a project test task and optionally the `--tests` option to run a subset of the tests:
+  * use a project test task and optionally the `--tests` option to run a subset of the tests.  Multiple `--tests` options may be specified following each test task.
     * `./gradlew <project>:test`
     * `./gradlew <project>:test --tests '*.SomeTest'`
     * `./gradlew <project>:test --tests '*.SomeTest.someMethod'`
+  * use the `cleanTest` task to force rerunning a previously successful test task (without forcing a rerun of all of the task's dependencies):
+    * `./gradlew [<project>:]cleanTest [<project>:]test`
 * `reports` : Generate JUnit and Code Coverage reports in `build\distributions\reports`. Use after executing the `test` target. 
   * `reports\tests\overview-summary.html` - JUnit test report
   * `reports\coverage\index.html` - Code coverage report

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -105,7 +105,7 @@ Running the reports target produces two reports:
 
 Work is ongoing to replace the Ant based build system with a Gradle based one
 [EDGENT-139].  Delivered functionality is expected to work though is not yet
-be complete.
+complete.
 
 **TODO: The primary build process is using Gradle, any pull request is expected to
 maintain the build success of `clean, assemble, test, reports`.**
@@ -130,7 +130,7 @@ unique tasks:
 * `reports` : Generate JUnit and Code Coverage reports in `build\distributions\reports`. Use after executing the `test` target. 
   * `reports\tests\overview-summary.html` - JUnit test report
   * `reports\coverage\index.html` - Code coverage report
-* `release` : Build a release bundle in `build/release-edgent`, **TODO: that includes subsets of the Edgent jars that run on Java 7 (`build/distributions/java7`) and Android (`build/distributions/android`)**.
+* `release` : Build a release bundle in `build/release-edgent`, that includes subsets of the Edgent jars that run on Java 7 (`build/distributions/java7`) and Android (`build/distributions/android`).
 
 The build process has been tested on Linux and MacOSX.
 

--- a/JAVA_SUPPORT.md
+++ b/JAVA_SUPPORT.md
@@ -9,6 +9,11 @@ Building a release `ant release` produces three sets of Jars under
 * target/java7 - Java 7 SE
 * target/android - Android
 
+[WIP] Building a release `./gradlew release` produces three sets of Jars under
+* build/distributions/java8 - Java 8 SE
+* build/distributions/java7 - Java 7 SE
+* build/distributions/android - Android
+
 This page documents which jars are expected to work in each environment.
 
 ## Core
@@ -37,6 +42,8 @@ This page documents which jars are expected to work in each environment.
 | Jar | Java 8 SE | Java 7 SE | Android | Notes |
 |---|---|---|---|---|
 |edgent.connectors.common.jar | yes | yes | yes | |
+|edgent.connectors.command.jar | yes | | | |
+|edgent.connectors.csv.jar | yes | | | |
 |edgent.connectors.file.jar | yes | | | |
 |edgent.connectors.http.jar | yes | yes | yes | |
 |edgent.connectors.iotf.jar | yes | yes | yes | |
@@ -68,6 +75,7 @@ This page documents which jars are expected to work in each environment.
 | Jar | Java 8 SE | Java 7 SE | Android | Notes |
 |---|---|---|---|---|
 |edgent.utils.metrics.jar | yes | | | |
+|edgent.utils.streamscope.jar | yes | | | |
 
 ### Development Console
 

--- a/analytics/math3/build.gradle
+++ b/analytics/math3/build.gradle
@@ -14,7 +14,7 @@
 dependencies {
   compile project(':api:topology')
   compile 'org.apache.commons:commons-math3:3.4.1'
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/analytics/sensors/build.gradle
+++ b/analytics/sensors/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/api/execution/build.gradle
+++ b/api/execution/build.gradle
@@ -13,5 +13,5 @@
  */
 dependencies {
   compile project(':api:function')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/api/function/build.gradle
+++ b/api/function/build.gradle
@@ -12,5 +12,5 @@
  * limitations under the License.
  */
 dependencies {
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/api/graph/build.gradle
+++ b/api/graph/build.gradle
@@ -13,5 +13,5 @@
  */
 dependencies {
   compile project(':api:oplet')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/api/oplet/build.gradle
+++ b/api/oplet/build.gradle
@@ -15,5 +15,5 @@ dependencies {
   compile project(':api:function')
   compile project(':api:execution')
   compile project(':api:window')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/api/topology/build.gradle
+++ b/api/topology/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile project(':api:execution')
   compile project(':api:graph')
   compile project(':api:oplet')
-  compile ext_classpath
+  compile core_ext_dependencies
 }
 
 //Build a jar file containing the applications to test the ApplicationService

--- a/api/window/build.gradle
+++ b/api/window/build.gradle
@@ -13,5 +13,5 @@
  */
 dependencies {
   compile project(':api:function')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ allprojects {
       url 'https://repo.eclipse.org/content/repositories/paho-snapshots/'
     }
   }
-
+  
   project.version = build_version
 }
 
@@ -55,7 +55,15 @@ ext {
   target_docs_dir = "${ext.target_dir}/docs"
   target_javadoc_dir = "${ext.target_docs_dir}/javadoc"
   target_report_dir = "${ext.target_dir}/reports"
+ 
+  // project groups whose jars are to be placed in target_java8_lib
+  // instead of the default "$target_java8_dir/$simpleProjectGroup/$project.name/lib"
+  //         e.g., "$target_java8_dir/lib" for api/topology
+  //         "$target_java8_dir/connectors/iotp/lib" for connectors/iotp
+  //
+  target_java8_lib_groups = ["api", "providers", "runtime", "spi"]
   
+  // TODO can these be deduced by the absence of a build.gradle for the project?
   aggregatorOnlyProjects = [
     ':analytics', ':api', ':apps',
     ':connectors', ':console', ':providers',
@@ -66,7 +74,166 @@ ext {
   filteredSubprojects = subprojects*.findAll { 
     project -> !aggregatorOnlyProjects.contains(project.path)
   }
+  
+  // for manifest classpath hackery
+  jarNameToProjectMap = [:]  // e.g., "edgent.connectors.iotp-0.4.0.jar" => Project(':component:iotp')
+  projectToJarNameMap = [:]
 }
+
+def recordProjectJar(Project proj) {
+  // manifest classpath hackery: update maps of project's jar <=> Project
+  def jarName = "${proj.group}.${proj.name}-${project.version}.jar"
+  jarNameToProjectMap[jarName] = proj
+  projectToJarNameMap[proj] = jarName
+  //println "#### updated jar <=> project maps: "+"$proj : $jarName"
+}
+
+def String mkJarNameFromSpec(String jarSpec) {
+  // e.g. 'com.google.code.gson:gson:2.2.4' => gson-2.2.4.jar
+  return jarSpec.split(':')[1] + '-' + jarSpec.split(':')[2] + '.jar'
+}
+
+def String stripJarNameVersion(String jarName) {
+  // e.g., edgent.api.topology-0.4.0.jar => edgent.api.topology.jar
+  return jarName.substring(0, jarName.lastIndexOf('-')) + '.jar'
+}
+
+def String getSimpleProjectGroup(Project proj) {
+  // e.g., 'edgent.api' => 'api'
+  return "$proj.group".replace("edgent.", "")
+}
+
+// create a path to dir2 relative to dir1
+// e.g., dir1:'lib', dir2:'connectors/iotp/lib' => ../connectors/iotp/lib
+def String mkRelativePath(File dir1, File dir2) {
+  def relPath = dir1.toPath().relativize(dir2.toPath())
+  //println "#### relPath: "+relPath+"   dir1:"+dir1+" dir2:"+dir2
+  return relPath.toString()
+}
+def String mkRelativePath(String dir1, String dir2) {
+  return mkRelativePath(new File(dir1), new File(dir2))
+}
+
+// e.g., =>  "lib" or "<component>/<subcomponent>/lib"
+def String getRelProjectDirInTargetDir(Project proj, String kind) {  // kind: "lib", "ext"
+  // the general case location
+  def simpleProjectGroup = getSimpleProjectGroup(proj);
+  def relProjDir = "$simpleProjectGroup/$proj.name/$kind"
+   
+  // special cases
+  if (target_java8_lib_groups.contains(simpleProjectGroup)) {
+    relProjDir = "$kind"
+  }
+  else if ('samples' == simpleProjectGroup) {
+    relProjDir = "$simpleProjectGroup/$kind"
+  }
+   
+  return relProjDir
+}
+
+// Get paths relative to the project's dir in the target-dir
+// to the project's immediate-only dependant project's jars
+// in their project's dir in the target dir
+// 
+// e.g., returns ['../../../lib/edgent.api.topology.jar', ...]
+def Collection getRelDirectDependantProjJars(Project proj) {
+  //println "#### proj: " + proj
+
+  def directDependantProjects = proj.configurations.compile.dependencies
+            .withType(ProjectDependency.class)
+            .collect { it.dependencyProject }
+  //println "#### directDependantProjects: " + directDependantProjects
+  
+  def directDependantProjJars = directDependantProjects.collect {
+    def relProjDirInTarget = getRelProjectDirInTargetDir(it, 'lib')
+    def jarName = projectToJarNameMap[it]
+    "$relProjDirInTarget/$jarName"
+  }
+  
+  // make relative paths from the project's dir in targetDir to the
+  // jars in the dependent projects' dir in targetDir
+  def myProjDirInTargetDir = getRelProjectDirInTargetDir(proj, 'lib')
+  def relDependantJars = directDependantProjJars.collect {
+    mkRelativePath(myProjDirInTargetDir, it)
+  }
+  //println "#### relDependantJars: "+relDependantJars
+  return relDependantJars
+}
+
+// e.g., returns ['../../../ext/gson-2.2.4.jar', ...]
+def Collection getRelCoreExtDependantJars(Project proj) {
+  // make relative paths from the project's dir in targetDir to the
+  // "ext" dir in targetDir
+  def myProjDirInTargetDir = getRelProjectDirInTargetDir(proj, 'lib')
+  def relDependantJars = ext_classpath.collect {
+    jarSpec ->
+    def jarName = mkJarNameFromSpec jarSpec
+    def relativeDependantJarDir = mkRelativePath(myProjDirInTargetDir, 'ext')
+    "$relativeDependantJarDir/$jarName"
+  }
+  //println "#### relDependantJars: "+relDependantJars
+  return relDependantJars
+}
+
+def String mkManifestClassPath(Project proj) {
+  // The manifest's classpath needs to include the project's:
+  // - immediate-only dependant edgent jars (not transitive and not their ext deps)
+  // - immediate dependant external jars and their transitive deps
+  // - the core_ext_dependency jars
+  
+  // TODO note: core_ext jars and their staging path ...
+  
+  def depProjJars = getRelDirectDependantProjJars proj
+  depProjJars = depProjJars.collect { stripJarNameVersion it }
+  
+  // TODO def projExtJars = getRelProjExtDependantJars proj
+  def projExtJars = []
+  
+  // unfortunate to include these if project didn't declare them as a dependency
+  // TODO related to come:  sample common jars
+  def coreExtJars = getRelCoreExtDependantJars proj
+    
+  def jars = []
+  jars.addAll depProjJars
+  jars.addAll projExtJars
+  jars.addAll coreExtJars
+    
+  def classPathStr = jars.join(' ')
+  //println "#### "+proj+" manifest classPath: "+classPathStr
+  return classPathStr
+}
+
+// ==================================================================
+// floundering trying to get a project's direct dependant project's
+// jars using the gradle object model.
+//
+// A hacky way now seems to be:
+// - identify the direct dependant projects
+// - formulate the jar name for each
+// - get all of the configuration's files (ends up transitive) and
+//   filter to select only those for direct dependent projects
+
+def Collection getDirectDependantProjJarsXXX(Project tgtProj) {
+println "#### tgtProj: " + tgtProj
+
+  def directDependantProjects = tgtProj.configurations.compile.dependencies
+            .withType ProjectDependency.class
+println "#### directDependantProjects: " + directDependantProjects
+
+  def dependantProjConfigs =  directDependantProjects.collect { it.projectConfiguration }
+println "#### configs: "+dependantProjConfigs
+  def dependantProjPublishArtifacts = dependantProjConfigs.collect { it.artifacts }
+println "#### dependantProjPublishArtifacts: "+dependantProjPublishArtifacts
+  def files = dependantProjPublishArtifacts.collect { it.files.getAsPath() }
+println "#### files: "+files
+
+  directDependantProjects = directDependantProjects.collect { it.dependencyProject }
+  
+  def jars = directDependantProjects.collect { getProjJar it }
+  println "#### jars: " + jars
+  return jars
+}
+// ==================================================================
 
 /* Configure subprojects */
 subprojects {
@@ -80,11 +247,14 @@ subprojects {
   apply plugin: 'java'
   apply plugin: "jacoco"
   ext.artifact = project.name
-  //group = 'org.apache.edgent'
  
   if (buildFile.isFile() && !buildFile.exists()) {
     configurations.create('default')
     return
+  }
+  
+  assemble { // in configure phase...
+    recordProjectJar(project)
   }
 
   if (["javax.websocket-client", "javax.websocket-server", "edgent.javax.websocket"].contains(project.name)) {
@@ -151,8 +321,12 @@ subprojects {
       attributes(
               'Implementation-Title': "${-> baseName}",
               'Implementation-Vendor': build_vendor,
+              // TODO inclusion of DSTAMP/TSTAMP results in regeneration
+              // of a jar when none of its contents/dependencies have changed.
+              // If possible use a canned DSTAMP/TSTAMP for non-"release" tasks
+              // to make the dev cycle more efficient at the expense of the TSTAMP.
               'Implementation-Version': "${commithash}-${DSTAMP}-${TSTAMP}",
-              // TODO Class-Path attribute
+              'Class-Path': mkManifestClassPath(project),
       )
     }
     metaInf {
@@ -167,49 +341,45 @@ subprojects {
     if(it.path == ":test:fvtiot" ||  it.path == ":providers:development") {
       dependsOn ":console:servlets"
     }
+  }
+  jar.doFirst {
     configure jarOptions
   }
 
   task copyJar(type: Copy) {
     description = "Copy subproject's assembled artifacts to target_dir (implicitly builds jars due to 'from jar')"
-    def projectGroup = "$project.group".replace("edgent.", "")
-
-    if (["api", "providers", "runtime", "spi"].contains(projectGroup)) {
-      // println "copyJar(cfg) lib $project.group $projectGroup $project.name $jar.archiveName"
+    
+    def relProjDirInTarget = getRelProjectDirInTargetDir(project, 'lib')
+    def absProjDirInTarget = "$target_java8_dir/$relProjDirInTarget"
+    
+    if (relProjDirInTarget != null) {
       from jar
-      into "${rootProject.ext.target_java8_dir}/lib"
+      into absProjDirInTarget
       rename("$jar.archiveName", "$jar.baseName.$jar.extension")
+    }
+
+    def simpleProjectGroup = getSimpleProjectGroup project
+    
+    // Copy war when appropriate
+    if (project.path == ':console:servlets') {
+      doLast {
+        copy {
+          from war
+          into "${rootProject.ext.target_java8_dir}/$simpleProjectGroup/webapps"
+        }
+      }
     } 
-    else if (["samples"].contains(projectGroup)) {
-      // println "copyJar(cfg) samples $project.group $projectGroup $project.name $jar.archiveName"
-      from jar
-      into "${rootProject.ext.target_java8_dir}/$projectGroup/lib"
-      rename("$jar.archiveName", "$jar.baseName.$jar.extension")
-
+    
+    // Copy SRC when appropriate
+    if (simpleProjectGroup == 'samples') {
       //Copy Sample SRC to dist
       doLast {
         copy {
           from(sourceSets.main.allSource.srcDirs) { include '**/*.java' }
-          into "${rootProject.ext.target_java8_dir}/$projectGroup/src/$project.name/src/main/java/"
+          into "${rootProject.ext.target_java8_dir}/$simpleProjectGroup/src/$project.name/src/main/java/"
         }
       }
     } 
-    else {
-      // println "copyJar(cfg) other $project.group $projectGroup $project.name $jar.archiveName"
-      from jar
-      into "${rootProject.ext.target_java8_dir}/$projectGroup/$project.name/lib"
-      rename("$jar.archiveName", "$jar.baseName.$jar.extension")
-      
-      // Copy console.war  (should be more general but this works for now)
-      if (projectGroup == 'console' && project.name == 'servlets') {
-        doLast {
-          copy {
-            from war
-            into "${rootProject.ext.target_java8_dir}/$projectGroup/webapps"
-          }
-        }
-      } 
-    }
   }
   
   task sourceJar(type: Jar) {

--- a/build.gradle
+++ b/build.gradle
@@ -272,11 +272,12 @@ def String mkManifestClassPath(Project proj) {
 }
 
 test {
-  println "\nHINT: to include tests than **/*Test.class you can: ./gradlew -Ptest.base.pattern='<path-pattern>.class' [project-scope:]test"
-  println "e.g. ./gradlew -Ptest.base.pattern='**/*TestManual.class' test"
-  println "e.g. ./gradlew -Ptest.base.pattern='**/MqttOpenTest.class' :connectors:mqtt:test"
-  println "To force a rerun of previously successful test task you can first specify the 'cleanTest' task"
-  println "e.g., ./gradlew :connectors:mqtt:cleanTest :connectors:mqtt:test"
+  println "\nHINTs: Use the '--tests <testClassNamePattern>[.<testMethodNamePattern>]' option to select specific test classes or methods."
+  println "    ./gradlew :api:topology:test --tests '*JsonFunctionsTest'"
+  println "    ./gradlew :api:topology:test --tests '*JsonFunctionsTest.testBytes'"
+  println "Use the 'cleanTest' task to force a rerun of a previously successful test task:"
+  println "    ./gradlew :api:topology:cleanTest :api:topology:test"
+  println "    ./gradlew cleanTest test"
   println ""
   sleep 1
 }
@@ -349,12 +350,9 @@ subprojects {
       dependsOn ":console:servlets"
     }
     
-    // see HINT in rootProject test task
-    def test_base_pattern = rootProject.hasProperty('test.base.pattern')
-         ? rootProject.getProperty('test.base.pattern')
-         : '**/*Test.class'
-         
-    include test_base_pattern
+    filter {
+      includeTestsMatching '*Test'  // can override via --tests command line option
+    }
 
     systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
     systemProperty 'edgent.test.root.dir', rootProject.projectDir

--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,8 @@ ext {
   // TODO can these be deduced by the absence of a build.gradle for the project?
   aggregatorOnlyProjects = [
     ':analytics', ':api', ':apps',
-    ':connectors', ':console', ':providers',
+    ':connectors', ':console',
+    ':platform', ':providers',
     ':runtime', ':samples', ':spi',
     ':test', ':utils'
   ]
@@ -810,10 +811,12 @@ task cleanAll {
 
 task release {
   description = 'Assemble distribution artifacts, populate target_dir, and create a release tgz'
-  dependsOn cleanAll, addMiscDistFiles, assemble, releaseTarGz
+  dependsOn cleanAll, addMiscDistFiles, assemble,
+       ':platform:java7:addJava7Target', ':platform:android:addAndroidTarget',
+       releaseTarGz
   addMiscDistFiles.mustRunAfter cleanAll
-  all.mustRunAfter addMiscDistFiles
-  releaseTarGz.mustRunAfter assemble
+  assemble.mustRunAfter addMiscDistFiles
+  releaseTarGz.mustRunAfter assemble,':platform:java7:addJava7Target',':platform:android:addAndroidTarget'
 }
 
 task reports {

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ allprojects {
   repositories {
     mavenCentral()
     maven {
+      // TODO - is this the right repo to use?
+      // related?... watson-iot-0.1.1.jar ends up referencing org.eclipse.paho.client.mqttv3-1.0.3-SNAPSHOT.jar
       url 'https://repo.eclipse.org/content/repositories/paho-snapshots/'
     }
   }
@@ -45,16 +47,15 @@ ext {
   now = new Date()
   DSTAMP = String.format('%tY%<tm%<td', now)
   TSTAMP = String.format('%tH%<tM', now)
-  ext_classpath = ['com.google.code.gson:gson:2.2.4',
-                   'org.slf4j:slf4j-api:1.7.12',
-                   'io.dropwizard.metrics:metrics-core:3.1.2']
+                   
   target_dir = "$distsDir"
-  target_java8_dir = "${ext.target_dir}/java8"
-  target_java7_dir = "${ext.target_dir}/java7"
-  target_android_dir = "${ext.target_dir}/android"
-  target_docs_dir = "${ext.target_dir}/docs"
-  target_javadoc_dir = "${ext.target_docs_dir}/javadoc"
-  target_report_dir = "${ext.target_dir}/reports"
+  target_java8_dir = "$target_dir/java8"
+  target_java8_ext_dir = "$target_java8_dir/ext"
+  target_java7_dir = "$target_dir/java7"
+  target_android_dir = "$target_dir/android"
+  target_docs_dir = "$target_dir/docs"
+  target_javadoc_dir = "$target_docs_dir/javadoc"
+  target_report_dir = "$target_dir/reports"
  
   // project groups whose jars are to be placed in target_java8_lib
   // instead of the default "$target_java8_dir/$simpleProjectGroup/$project.name/lib"
@@ -78,14 +79,38 @@ ext {
   // for manifest classpath hackery
   jarNameToProjectMap = [:]  // e.g., "edgent.connectors.iotp-0.4.0.jar" => Project(':component:iotp')
   projectToJarNameMap = [:]
+  
+  // Edgent core external dependencies
+  core_ext_dependencies = ['com.google.code.gson:gson:2.2.4',
+                   'org.slf4j:slf4j-api:1.7.12',
+                   'io.dropwizard.metrics:metrics-core:3.1.2']
+  copied_core_ext_dependencies_jars = false
+  
+  // Edgent Samples external dependencies
+  samples_ext_dependencies = ['org.slf4j:slf4j-jdk14:1.7.12']
+  copied_samples_ext_dependencies_jars = false
+
+  // Edgent tests external dependencies
+  tests_ext_dependencies = ['org.slf4j:slf4j-jdk14:1.7.12']
+  copied_tests_ext_dependencies_jars = false
+  
+  common_ext_dependencies = [
+    core_ext_dependencies,
+    samples_ext_dependencies,
+    // tests_ext_dependencies, // omit as tests aren't included in release tgz
+  ].flatten()
 }
 
 def recordProjectJar(Project proj) {
   // manifest classpath hackery: update maps of project's jar <=> Project
+  // This, and use of these maps, is fallout from floundering
+  // trying to leverage the gradle object model for dealing with
+  // project (and dependent project) artifacts and/or other nice
+  // gradle declaritive-isms for dealing with this.
   def jarName = "${proj.group}.${proj.name}-${project.version}.jar"
   jarNameToProjectMap[jarName] = proj
   projectToJarNameMap[proj] = jarName
-  //println "#### updated jar <=> project maps: "+"$proj : $jarName"
+  //println "#### $proj.path updated jar <=> project maps: $jarName"
 }
 
 def String mkJarNameFromSpec(String jarSpec) {
@@ -115,7 +140,7 @@ def String mkRelativePath(String dir1, String dir2) {
 }
 
 // e.g., =>  "lib" or "<component>/<subcomponent>/lib"
-def String getRelProjectDirInTargetDir(Project proj, String kind) {  // kind: "lib", "ext"
+def String getTargetRelProjDir(Project proj, String kind) {  // kind: "lib", "ext"
   // the general case location
   def simpleProjectGroup = getSimpleProjectGroup(proj);
   def relProjDir = "$simpleProjectGroup/$proj.name/$kind"
@@ -136,104 +161,115 @@ def String getRelProjectDirInTargetDir(Project proj, String kind) {  // kind: "l
 // in their project's dir in the target dir
 // 
 // e.g., returns ['../../../lib/edgent.api.topology.jar', ...]
-def Collection getRelDirectDependantProjJars(Project proj) {
-  //println "#### proj: " + proj
+def Collection getTargetRelDirectDependantProjJars(Project proj) {
 
   def directDependantProjects = proj.configurations.compile.dependencies
             .withType(ProjectDependency.class)
             .collect { it.dependencyProject }
-  //println "#### directDependantProjects: " + directDependantProjects
+  //println "#### $proj.path directDependantProjects: $directDependantProjects"
   
   def directDependantProjJars = directDependantProjects.collect {
-    def relProjDirInTarget = getRelProjectDirInTargetDir(it, 'lib')
+    def relProjDirInTarget = getTargetRelProjDir(it, 'lib')
     def jarName = projectToJarNameMap[it]
     "$relProjDirInTarget/$jarName"
   }
   
   // make relative paths from the project's dir in targetDir to the
   // jars in the dependent projects' dir in targetDir
-  def myProjDirInTargetDir = getRelProjectDirInTargetDir(proj, 'lib')
+  def myProjDirInTargetDir = getTargetRelProjDir(proj, 'lib')
   def relDependantJars = directDependantProjJars.collect {
     mkRelativePath(myProjDirInTargetDir, it)
   }
-  //println "#### relDependantJars: "+relDependantJars
+  //println "#### $proj.path relDependantJars: $relDependantJars"
   return relDependantJars
 }
 
 // e.g., returns ['../../../ext/gson-2.2.4.jar', ...]
-def Collection getRelCoreExtDependantJars(Project proj) {
+def Collection getTargetRelDependantCommonExtJars(Project proj, Collection ext_dependencies) {
   // make relative paths from the project's dir in targetDir to the
-  // "ext" dir in targetDir
-  def myProjDirInTargetDir = getRelProjectDirInTargetDir(proj, 'lib')
-  def relDependantJars = ext_classpath.collect {
+  // "ext" dir in targetDir (target_java8_ext_dir)
+  def myProjDirInTargetDir = getTargetRelProjDir(proj, 'lib')
+  def relDependantJars = ext_dependencies.collect {
     jarSpec ->
-    def jarName = mkJarNameFromSpec jarSpec
-    def relativeDependantJarDir = mkRelativePath(myProjDirInTargetDir, 'ext')
-    "$relativeDependantJarDir/$jarName"
+      def jarName = mkJarNameFromSpec jarSpec
+      def relativeDependantJarDir = mkRelativePath(myProjDirInTargetDir, 'ext')
+      "$relativeDependantJarDir/$jarName"
   }
-  //println "#### relDependantJars: "+relDependantJars
+  //println "#### $proj.path relDependantJars: $relDependantJars"
   return relDependantJars
+}
+
+def getProjectExtDepFiles(Project proj) { // project's direct ext deps and their transitive deps
+  // TODO suspect this is picking up ext dependencies of transitive **project** dependencies???
+  def allExtDepFiles = proj.configurations.runtime.files { it instanceof ExternalDependency }
+  logger.info "$proj.path allExtDepFiles: "+allExtDepFiles
+  return allExtDepFiles
+}
+ 
+def getProjectNonCommonExtDepFiles(Project proj) {
+  // filter out "common" (target_java8_ext_dir) external dependencies
+  def commonExtJarNames = common_ext_dependencies.collect {
+    mkJarNameFromSpec it
+  }
+  def filteredExtDepFiles = getProjectExtDepFiles(proj).findAll {
+    ! commonExtJarNames.contains(it.getName())
+  }
+  return filteredExtDepFiles
+}
+
+// Get paths relative to the project's lib dir in the target-dir
+// to the project's immediate external jar dependencies (and their dependencies
+// transitively) in the project's ext dir in the target dir
+//
+// Should NOT include any external dependencies from the project's dependant *projects* (transitively)
+// TODO fix that
+// 
+// e.g., returns ['../ext/jetty-...', ...]
+def Collection getTargetRelDependantProjExtJars(Project proj) {
+  def myProjLibDirInTargetDir = getTargetRelProjDir(proj, 'lib')
+  def myProjExtDirInTargetDir = getTargetRelProjDir(proj, 'ext')
+  def relProjExtDirPath = mkRelativePath(myProjLibDirInTargetDir, myProjExtDirInTargetDir)
+    
+  // assumes updateTargetDir task copies all the project's ext dependencies
+  // to <projectDirInTarget>/ext
+  
+  def relProjExtDeps = getProjectNonCommonExtDepFiles(proj).collect {
+    file -> "$relProjExtDirPath/$file.name"
+  }
+  //println "#### $proj.path relProjExtDeps: $relProjExtDeps"
+  return relProjExtDeps
 }
 
 def String mkManifestClassPath(Project proj) {
   // The manifest's classpath needs to include the project's:
   // - immediate-only dependant edgent jars (not transitive and not their ext deps)
+  // - "other" dependant external jars - e.g., samples_ext_dependencies
   // - immediate dependant external jars and their transitive deps
-  // - the core_ext_dependency jars
+  // - the core_ext_dependencies jars
   
-  // TODO note: core_ext jars and their staging path ...
-  
-  def depProjJars = getRelDirectDependantProjJars proj
+  def depProjJars = getTargetRelDirectDependantProjJars proj
   depProjJars = depProjJars.collect { stripJarNameVersion it }
   
-  // TODO def projExtJars = getRelProjExtDependantJars proj
-  def projExtJars = []
+  def projExtJars = getTargetRelDependantProjExtJars proj
   
   // unfortunate to include these if project didn't declare them as a dependency
-  // TODO related to come:  sample common jars
-  def coreExtJars = getRelCoreExtDependantJars proj
+  def coreExtJars = getTargetRelDependantCommonExtJars(proj, core_ext_dependencies)
+  
+  def otherExtJars = []
+  if (proj.path ==~ '^:samples.*') {
+     otherExtJars.addAll getTargetRelDependantCommonExtJars(proj, samples_ext_dependencies)
+  }
     
   def jars = []
   jars.addAll depProjJars
+  jars.addAll otherExtJars
   jars.addAll projExtJars
   jars.addAll coreExtJars
     
   def classPathStr = jars.join(' ')
-  //println "#### "+proj+" manifest classPath: "+classPathStr
+  //println "#### $proj.path manifest-classPath: $classPathStr"
   return classPathStr
 }
-
-// ==================================================================
-// floundering trying to get a project's direct dependant project's
-// jars using the gradle object model.
-//
-// A hacky way now seems to be:
-// - identify the direct dependant projects
-// - formulate the jar name for each
-// - get all of the configuration's files (ends up transitive) and
-//   filter to select only those for direct dependent projects
-
-def Collection getDirectDependantProjJarsXXX(Project tgtProj) {
-println "#### tgtProj: " + tgtProj
-
-  def directDependantProjects = tgtProj.configurations.compile.dependencies
-            .withType ProjectDependency.class
-println "#### directDependantProjects: " + directDependantProjects
-
-  def dependantProjConfigs =  directDependantProjects.collect { it.projectConfiguration }
-println "#### configs: "+dependantProjConfigs
-  def dependantProjPublishArtifacts = dependantProjConfigs.collect { it.artifacts }
-println "#### dependantProjPublishArtifacts: "+dependantProjPublishArtifacts
-  def files = dependantProjPublishArtifacts.collect { it.files.getAsPath() }
-println "#### files: "+files
-
-  directDependantProjects = directDependantProjects.collect { it.dependencyProject }
-  
-  def jars = directDependantProjects.collect { getProjJar it }
-  println "#### jars: " + jars
-  return jars
-}
-// ==================================================================
 
 /* Configure subprojects */
 subprojects {
@@ -246,7 +282,6 @@ subprojects {
   apply plugin: 'maven-publish'
   apply plugin: 'java'
   apply plugin: "jacoco"
-  ext.artifact = project.name
  
   if (buildFile.isFile() && !buildFile.exists()) {
     configurations.create('default')
@@ -346,40 +381,89 @@ subprojects {
     configure jarOptions
   }
 
-  task copyJar(type: Copy) {
-    description = "Copy subproject's assembled artifacts to target_dir (implicitly builds jars due to 'from jar')"
-    
-    def relProjDirInTarget = getRelProjectDirInTargetDir(project, 'lib')
-    def absProjDirInTarget = "$target_java8_dir/$relProjDirInTarget"
-    
-    if (relProjDirInTarget != null) {
-      from jar
-      into absProjDirInTarget
-      rename("$jar.archiveName", "$jar.baseName.$jar.extension")
-    }
-
-    def simpleProjectGroup = getSimpleProjectGroup project
-    
-    // Copy war when appropriate
-    if (project.path == ':console:servlets') {
-      doLast {
-        copy {
-          from war
-          into "${rootProject.ext.target_java8_dir}/$simpleProjectGroup/webapps"
+  task updateTargetDir() {
+    description = "Copy subproject's assembled artifacts to target_dir (implicitly builds jars due to 'from jar')"    
+    doLast {
+      def simpleProjectGroup = getSimpleProjectGroup(project)
+      
+      // Copy the project's jar or war
+      def relProjDirInTarget = getTargetRelProjDir(project, 'lib')
+      if (relProjDirInTarget != null) {
+        if (project.pluginManager.hasPlugin('war')) {
+          copy {
+            from war
+            into "$target_java8_dir/$simpleProjectGroup/webapps"
+          }
+        }
+        else {
+          copy {
+            from jar
+            into "$target_java8_dir/$relProjDirInTarget"
+            rename("$jar.archiveName", "$jar.baseName.$jar.extension")
+          }
         }
       }
-    } 
     
-    // Copy SRC when appropriate
-    if (simpleProjectGroup == 'samples') {
-      //Copy Sample SRC to dist
-      doLast {
+      // Copy SRC when appropriate
+      if (simpleProjectGroup == 'samples') {
         copy {
           from(sourceSets.main.allSource.srcDirs) { include '**/*.java' }
-          into "${rootProject.ext.target_java8_dir}/$simpleProjectGroup/src/$project.name/src/main/java/"
+          into "$target_java8_dir/$simpleProjectGroup/src/$project.name/src/main/java/"
         }
       }
-    } 
+
+      // Copy the project's external dependencies (transitively)
+      // TODO we're getting more transitive ext deps
+      // in some cases - e.g., for watson iot we "knew" we only needed a subset
+      // of all watson iot deps known to maven
+      
+      def projectExtDir = getTargetRelProjDir(project, 'ext')
+      def nonCommonExtFiles = getProjectNonCommonExtDepFiles(project)
+      logger.info "$project.path copying extDepFiles jars: "+nonCommonExtFiles.collect { it.getName() }
+      //println "#### $project.path copying extDepFiles jars: "+nonCommonExtFiles.collect { it.getName() }
+      copy {
+        from nonCommonExtFiles
+        includeEmptyDirs = false
+        into "$target_java8_dir/$projectExtDir"
+      }
+    
+      // Copy core_ext_dependencies jars once
+      if (!copied_core_ext_dependencies_jars) {
+        copied_core_ext_dependencies_jars = true
+        def coreExtJarNames = core_ext_dependencies.collect {
+          mkJarNameFromSpec it
+        }
+        def coreExtDeps = getProjectExtDepFiles(project).findAll {
+          coreExtJarNames.contains(it.getName())
+        }
+        logger.info "$project.path copying core_ext_dependencies_jars: "+coreExtDeps.collect { it.getName() }
+        //println "#### $project.path copying core_ext_dependencies_jars: "+coreExtDeps.collect { it.getName() }
+        copy {
+          from coreExtDeps
+          includeEmptyDirs = false
+          into target_java8_ext_dir
+        }
+      }
+
+      // Copy samples_ext_dependencies jars once
+      if ('samples' == simpleProjectGroup && !copied_samples_ext_dependencies_jars) {
+        copied_samples_ext_dependencies_jars = true
+        def samplesExtJarNames = samples_ext_dependencies.collect {
+          mkJarNameFromSpec it
+        }
+        def commonExtDeps = getProjectExtDepFiles(project).findAll {
+          samplesExtJarNames.contains(it.getName())
+        }
+        logger.info "$project.path copying samples_ext_dependencies_jars: "+commonExtDeps.collect { it.getName() }
+        //println "#### $project.path copying samples_ext_dependencies_jars: "+commonExtDeps.collect { it.getName() }
+        copy {
+          from commonExtDeps
+          includeEmptyDirs = false
+          into target_java8_ext_dir
+        }
+      }
+      
+    } // doLast
   }
   
   task sourceJar(type: Jar) {
@@ -408,14 +492,14 @@ subprojects {
   }  
   
   // assemble: inject updating target_dir 
-  assemble.finalizedBy copyJar
+  assemble.finalizedBy updateTargetDir
 }
 
 task copyScripts(type: Copy) {
   description = 'Copy scripts to target_java8_dir'
   includeEmptyDirs = false
   from("scripts/") { include "**/*" }
-  into "${rootProject.ext.target_java8_dir}/scripts/"
+  into "$target_java8_dir/scripts/"
 }
 
 //Create Junit Report
@@ -604,7 +688,7 @@ task jacocoTestReport << {
 
 task aggregateJavadoc(type: Javadoc) {
   description = 'Create all javadoc into target_dir/docs/javadoc'
-  destinationDir file("$rootProject.ext.target_javadoc_dir")
+  destinationDir file(target_javadoc_dir)
   options.addStringOption('Xdoclint:none', '-quiet')
   configure(options) {
     author = true
@@ -612,7 +696,7 @@ task aggregateJavadoc(type: Javadoc) {
     use = true
     docTitle "Apache Edgent (incubating) v${build_version}"
     footer '<a href="http://edgent.incubator.apache.org">Apache Edgent (incubating)</a>'
-    bottom "Copyright &#169; 2016 The Apache Software Foundation. All Rights Reserved - ${rootProject.ext.commithash}-${DSTAMP}-${TSTAMP}"
+    bottom "Copyright &#169; 2016 The Apache Software Foundation. All Rights Reserved - ${commithash}-${DSTAMP}-${TSTAMP}"
     overview "edgent_overview.html"
     windowTitle "Edgent v${build_version}"
 
@@ -641,7 +725,7 @@ task aggregateJavadoc(type: Javadoc) {
       from subprojects.collect { project -> project.sourceSets.main.java.srcDirs }
       include '**/doc-files/**'
       includeEmptyDirs = false
-      into "$rootProject.ext.target_javadoc_dir"
+      into target_javadoc_dir
     }
   }
 }
@@ -656,14 +740,14 @@ task addVersionDotTxt {
       'commithash.error': "$commithash_error",
       'edgent.version': "$build_version",
       ]
-    def f = new File("${rootProject.ext.target_dir}/version.txt");
+    def f = new File("$target_dir/version.txt");
     f.createNewFile()
     map.forEach { k,v -> f.append "$k=$v\n" }
   }
 }
 
 task mkTargetDir << {
-    def d = new File(rootProject.ext.target_dir);
+    def d = new File(target_dir);
     if( !d.exists() ) { d.mkdirs() }
 }
 
@@ -685,10 +769,10 @@ task releaseTarGz(type: Tar) {
   duplicatesStrategy 'exclude'
   into "${build_name}"
   // make some things first in the tgz
-  from "${rootProject.ext.target_dir}/LICENSE"
-  from "${rootProject.ext.target_dir}/README.md"
-  from "${rootProject.ext.target_dir}/version.txt"
-  from rootProject.ext.target_dir
+  from "$target_dir/LICENSE"
+  from "$target_dir/README.md"
+  from "$target_dir/version.txt"
+  from target_dir
   doLast {
     ant.checksum algorithm: 'md5', file: archivePath
     ant.checksum algorithm: 'sha1', file: archivePath

--- a/build.gradle
+++ b/build.gradle
@@ -271,6 +271,16 @@ def String mkManifestClassPath(Project proj) {
   return classPathStr
 }
 
+test {
+  println "\nHINT: to include tests than **/*Test.class you can: ./gradlew -Ptest.base.pattern='<path-pattern>.class' [project-scope:]test"
+  println "e.g. ./gradlew -Ptest.base.pattern='**/*TestManual.class' test"
+  println "e.g. ./gradlew -Ptest.base.pattern='**/MqttOpenTest.class' :connectors:mqtt:test"
+  println "To force a rerun of previously successful test task you can first specify the 'cleanTest' task"
+  println "e.g., ./gradlew :connectors:mqtt:cleanTest :connectors:mqtt:test"
+  println ""
+  sleep 1
+}
+
 /* Configure subprojects */
 subprojects {
 
@@ -338,7 +348,13 @@ subprojects {
     if(it.path == ":test:fvtiot" ||  it.path == ":providers:development") {
       dependsOn ":console:servlets"
     }
-    include '**/*Test.class'
+    
+    // see HINT in rootProject test task
+    def test_base_pattern = rootProject.hasProperty('test.base.pattern')
+         ? rootProject.getProperty('test.base.pattern')
+         : '**/*Test.class'
+         
+    include test_base_pattern
 
     systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
     systemProperty 'edgent.test.root.dir', rootProject.projectDir

--- a/build.gradle
+++ b/build.gradle
@@ -788,6 +788,8 @@ task releaseTarGz(type: Tar) {
   from "$target_dir/README.md"
   from "$target_dir/version.txt"
   from target_dir
+  exclude '**/test/svt/'
+  exclude '**/connectors/javax.websocket-server/' // just part of wsclient test harness
   doLast {
     ant.checksum algorithm: 'md5', file: archivePath
     ant.checksum algorithm: 'sha1', file: archivePath

--- a/connectors/command/build.gradle
+++ b/connectors/command/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile project(':api:topology')
   compile project(':connectors:common')
   testCompile project(':providers:direct')
-  testRuntime ext_classpath
+  testRuntime core_ext_dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/common/build.gradle
+++ b/connectors/common/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/csv/build.gradle
+++ b/connectors/csv/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/edgent.javax.websocket/build.gradle
+++ b/connectors/edgent.javax.websocket/build.gradle
@@ -15,5 +15,5 @@ archivesBaseName = project.name
 
 dependencies {
   compile 'javax.websocket:javax.websocket-api:1.0'
-  testRuntime ext_classpath
+  testRuntime core_ext_dependencies
 }

--- a/connectors/file/build.gradle
+++ b/connectors/file/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/http/build.gradle
+++ b/connectors/http/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile project(':api:topology')
   compile 'org.apache.httpcomponents:httpclient:4.5.1'
   compile 'org.apache.httpcomponents:httpcore:4.4.4'
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/iot/build.gradle
+++ b/connectors/iot/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/iotp/build.gradle
+++ b/connectors/iotp/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile project(':api:topology')
   compile project(':connectors:iot')
   compile 'com.ibm.messaging:watson-iot:0.1.1'
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/javax.websocket-client/build.gradle
+++ b/connectors/javax.websocket-client/build.gradle
@@ -16,5 +16,5 @@ archivesBaseName = project.name
 dependencies {
   compile project(':connectors:edgent.javax.websocket')
   compile 'org.eclipse.jetty.websocket:javax-websocket-client-impl:9.3.6.v20151106'
-  testRuntime ext_classpath
+  testRuntime core_ext_dependencies
 }

--- a/connectors/javax.websocket-server/build.gradle
+++ b/connectors/javax.websocket-server/build.gradle
@@ -16,5 +16,5 @@ archivesBaseName = project.name
 dependencies {
   compile project(':connectors:javax.websocket-client')
   compile 'org.eclipse.jetty.websocket:javax-websocket-server-impl:9.3.6.v20151106'
-  testRuntime ext_classpath
+  testRuntime core_ext_dependencies
 }

--- a/connectors/jdbc/build.gradle
+++ b/connectors/jdbc/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/kafka/build.gradle
+++ b/connectors/kafka/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile project(':api:topology')
   compile 'org.apache.kafka:kafka_2.10:0.8.2.2'
   compile 'org.apache.kafka:kafka-clients:0.8.2.2'
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/mqtt/build.gradle
+++ b/connectors/mqtt/build.gradle
@@ -17,7 +17,7 @@ dependencies {
   compile project(':connectors:common')
   compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.2'
   testCompile project(':providers:direct')
-  testRuntime ext_classpath
+  testRuntime core_ext_dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/pubsub/build.gradle
+++ b/connectors/pubsub/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/serial/build.gradle
+++ b/connectors/serial/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/connectors/wsclient-javax.websocket/build.gradle
+++ b/connectors/wsclient-javax.websocket/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   testCompile project(':providers:direct')
   testCompile project(':connectors:javax.websocket-client')
   testCompile project(':connectors:javax.websocket-server')
-  testRuntime ext_classpath
+  testRuntime core_ext_dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/wsclient/build.gradle
+++ b/connectors/wsclient/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':providers:direct')
 }
 

--- a/console/server/build.gradle
+++ b/console/server/build.gradle
@@ -20,5 +20,5 @@ dependencies {
   compile 'org.eclipse.jetty:jetty-util:9.3.6.v20151106'
   compile 'org.eclipse.jetty:jetty-webapp:9.3.6.v20151106'
   compile 'org.eclipse.jetty:jetty-xml:9.3.6.v20151106'
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/console/servlets/build.gradle
+++ b/console/servlets/build.gradle
@@ -18,7 +18,7 @@ plugins.apply 'war'
 dependencies {
   providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
   providedCompile project(':utils:streamscope')
-  providedCompile ext_classpath
+  providedCompile core_ext_dependencies
 }
 
 war {

--- a/platform/android/build.gradle
+++ b/platform/android/build.gradle
@@ -1,0 +1,63 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+defaultTasks 'addAndroidTarget'
+
+// Avoid creating/staging an empty jar (this is a 'java' subproject) 
+jar {
+  deleteAllActions()
+}
+
+// let the existing ant script do all of the work
+
+ant.importBuild('build.xml') { antTargetName ->
+  'ant_' + antTargetName
+}
+
+ant.properties['edgent8.target'] = target_java8_dir
+ant.properties['edgent7.target'] = target_java7_dir
+ant.properties['edgent.android.target'] = target_android_dir
+
+clean {
+  dependsOn ant_clean
+}
+
+task addAndroidTarget {
+  description = "Assemble distribution artifacts for android (from java7 artifacts)"
+  dependsOn ':platform:java7:addJava7Target', clean, ant_all
+  ant_all.mustRunAfter ':platform:java7:addJava7Target'
+  ant_all.mustRunAfter clean
+  
+  // TODO the following isn't cutting it for adding up-to-date for this task
+  // so as to avoid unnecessarily running clean,ant_all
+  // ... well things just don't quite work the way I hoped.
+  // A task's dependencies are run before a task is checked for UTD
+  // inputs.dir(target_java7_dir)
+  // outputs.dir(target_android_dir)
+}
+
+// unlike the above, this has the benefit(?) of producing the ant output to stdout
+// But it requires 'ant' to be in the path and doesn't (can't?) use
+// the ant that's embedded with gradle hmm...
+//
+//task androidXXX(type: Exec) {
+//  description = "Assemble distribution artifacts for android (from java7 artifacts)"
+//  dependsOn :platform:java7:java7
+//  workingDir 'platform/android'
+//  commandLine 'ant', 'clean', 'all',
+//     '-Dedgent8.target=../../build/distributions/java8',
+//     '-Dedgent7.target=../../build/distributions/java7',
+//     '-Dedgent.android.target=../../build/distributions/android'
+//}
+

--- a/platform/android/build.xml
+++ b/platform/android/build.xml
@@ -38,7 +38,7 @@
   <target name="copyFrom7" depends="init">
     <copy todir="${edgent.android.target}">
        <fileset dir="${edgent7.target}"
-           excludes="scripts/** lib/edgent.runtime.jmxcontrol.jar"
+           excludes="scripts/** lib/edgent.runtime.jmxcontrol.jar lib/edgent.providers.development.jar console/**"
        />
 
     </copy>
@@ -46,6 +46,10 @@
     <!-- They get built there and are processed through the retrolambda -->
     <delete dir="${edgent8.target}/android"/>
     <delete dir="${edgent7.target}/android"/>
+  </target>
+
+  <target name="clean">
+    <delete dir="${edgent.android.target}"/>
   </target>
 
 </project>

--- a/platform/java7/build.gradle
+++ b/platform/java7/build.gradle
@@ -1,0 +1,74 @@
+/*
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+defaultTasks 'addJava7Target'
+
+// Avoid creating/staging an empty jar (this is a 'java' subproject) 
+jar {
+  deleteAllActions()
+}
+
+// let the existing ant script do all of the work
+
+ant.importBuild('build.xml') { antTargetName ->
+  'ant_' + antTargetName
+}
+
+ant.properties['edgent8.target'] = target_java8_dir
+ant.properties['edgent7.target'] = target_java7_dir
+ant.properties['ext.dir'] = target_java8_ext_dir
+ant.properties['slf4j.ext.dir'] = ""
+ant.properties['gson.ext.dir'] = ""
+ant.properties['metrics.ext.dir'] = ""
+
+clean {
+  dependsOn ant_clean
+}
+
+ant_retro7.doFirst { 
+  println "Performing a long running ant task (run with --info to see it all)..."
+}
+
+task addJava7Target {
+  description = "Assemble distribution artifacts for java7 (from java8 artifacts)"
+  dependsOn ':assemble', clean, ant_retro7
+  ant_retro7.mustRunAfter clean
+  ant_retro7.mustRunAfter ':assemble'
+  
+  // TODO the following isn't cutting it for adding up-to-date for this task
+  // so as to avoid unnecessarily running clean,retro7
+  // ... well things just don't quite work the way I hoped.
+  // A task's dependencies are run before a task is checked for UTD
+  // inputs.dir(target_java8_dir)
+  // outputs.dir(target_java7_dir)
+}
+
+// unlike the above, this has the benefit(?) of producing the ant output to stdout
+// But it requires 'ant' to be in the path and doesn't (can't?) use
+// the ant that's embedded with gradle hmm...
+//
+//task java7XXX(type: Exec) {
+//  description = "Assemble distribution artifacts for java7 (from java8 artifacts)"
+//  dependsOn ':assemble'
+//  workingDir 'platform/java7'
+//  commandLine 'ant', 'clean', 'retro7',
+//     '-Dedgent8.target=../../build/distributions/java8',
+//     '-Dedgent7.target=../../build/distributions/java7',
+//     '-Dext.dir=../../build/distributions/java8/ext',
+//     '-Dslf4j.ext.dir=""',
+//     '-Dgson.ext.dir=""',
+//     '-Dmetrics.ext.dir=""'
+//}
+
+

--- a/platform/java7/build.gradle
+++ b/platform/java7/build.gradle
@@ -37,7 +37,7 @@ clean {
 }
 
 ant_retro7.doFirst { 
-  println "Performing a long running ant task (run with --info to see it all)..."
+  println "Performing a longer running ant task (e.g., ~30sec; run with --info to see it all)..."
 }
 
 task addJava7Target {

--- a/platform/java7/build.xml
+++ b/platform/java7/build.xml
@@ -268,25 +268,13 @@
 		<retro7.test.setup tdir="runtime/jsoncontrol" />
 		<retro7.test.setup tdir="runtime/jobregistry" />
 		<retro7.test.setup tdir="utils/metrics"  ldir="utils/metrics/lib"/>
-        <!-- utils/streamscope - why not java7? -->
 		<retro7.test.setup tdir="providers/direct" />
-        <!-- providers/development - why not java7? -->
 		<retro7.test.setup tdir="connectors/common" ldir="connectors/common/lib"/>
 		<retro7.test.setup tdir="connectors/iotp"  ldir="connectors/iotp/lib"/>
 		<retro7.test.setup tdir="connectors/http"  ldir="connectors/http/lib"/>
 		<retro7.test.setup tdir="connectors/pubsub"  ldir="connectors/pubsub/lib"/>
-        <!-- connectors/command - why not java7? -->
-        <!-- connectors/csv - why not java7? -->
-        <!-- connectors/file - why not java7? -->
-        <!-- connectors/jdbc - why not java7? -->
-        <!-- connectors/mqtt - why not java7? -->
-        <!-- connectors/kafka - why not java7? -->
-        <!-- connectors/wsclient - why not java7? -->
-        <!-- connectors/javax.websocket-client - why not java7? -->
 		<retro7.test.setup tdir="apps/iot"  ldir="apps/iot/lib"/>
 		<retro7.test.setup tdir="apps/runtime"  ldir="apps/runtime/lib"/>
-        <!-- analytics/math3 - why not java7? -->
-        <!-- analytics/sensors - why not java7? -->
 	</target>
 
         <!--
@@ -310,25 +298,13 @@
 		<retro7.test.run tdir="runtime/jsoncontrol" />
 		<retro7.test.run tdir="runtime/jobregistry" />
 		<retro7.test.run tdir="utils/metrics"  ldir="utils/metrics/lib"/>
-        <!-- utils/streamscope - why not java7? -->
 		<retro7.test.run tdir="providers/direct" />
-        <!-- providers/development - why not java7? -->
 		<retro7.test.run tdir="connectors/common" ldir="connectors/common/lib"/>
 		<retro7.test.run tdir="connectors/iotp"  ldir="connectors/iotp/lib"/>
 		<retro7.test.run tdir="connectors/http"  ldir="connectors/http/lib"/>
 		<retro7.test.run tdir="connectors/pubsub"  ldir="connectors/pubsub/lib"/>
-        <!-- connectors/command - why not java7? -->
-        <!-- connectors/csv - why not java7? -->
-        <!-- connectors/file - why not java7? -->
-        <!-- connectors/jdbc - why not java7? -->
-        <!-- connectors/mqtt - why not java7? -->
-        <!-- connectors/kafka - why not java7? -->
-        <!-- connectors/wsclient - why not java7? -->
-        <!-- connectors/javax.websocket-client - why not java7? -->
 		<retro7.test.run tdir="apps/iot"  ldir="apps/iot/lib"/>
 		<retro7.test.run tdir="apps/runtime"  ldir="apps/runtime/lib"/>
-        <!-- analytics/math3 - why not java7? -->
-        <!-- analytics/sensors - why not java7? -->
 	</target>
 
 	<target name="clean">

--- a/platform/java7/build.xml
+++ b/platform/java7/build.xml
@@ -32,11 +32,19 @@
 	<property name="output.dir" location="classes.out"/>
 	<property name="test.classes.dir" location="classes.test"/>
 	<property name="ext.dir" location="${edgent}/ext"/>
+	
+    <property name="slf4j.version" location="1.7.12"/>
+    <property name="gson.version" location="2.2.4"/>
+    <property name="metrics.version" location="3.1.2"/>
+
+	<property name="slf4j.ext.dir" location="slf4j-${slf4j.version}/"/>
+    <property name="gson.ext.dir" location="google-gson-${gson.version}/"/>
+    <property name="metrics.ext.dir" location="metrics-${metrics.version}/"/>
 
 	<path id="edgent.classpath">
-		<pathelement location="${ext.dir}/slf4j-1.7.12/slf4j-api-1.7.12.jar"/>
-		<pathelement location="${ext.dir}/google-gson-2.2.4/gson-2.2.4.jar"/>
-		<pathelement location="${ext.dir}/metrics-3.1.2/metrics-core-3.1.2.jar"/>
+        <pathelement location="${ext.dir}/${slf4j.ext.dir}slf4j-api-${slf4j.version}.jar"/>
+        <pathelement location="${ext.dir}/${gson.ext.dir}gson-${gson.version}.jar"/>
+        <pathelement location="${ext.dir}/${metrics.ext.dir}metrics-core-${metrics.version}.jar"/>
 	</path>
 	<property name="qcp" refid="edgent.classpath"/>
 
@@ -112,14 +120,26 @@
 		<retro7 qjar="edgent.runtime.jobregistry.jar" />
 
 		<retro7 qjar="edgent.utils.metrics.jar" qdir="utils/metrics/lib" />
+        <!-- utils/streamscope - why not java7? -->
 		<retro7 qjar="edgent.providers.direct.jar" />
+        <!-- providers/development - why not java7? -->
 		<retro7 qjar="edgent.connectors.common.jar"  qdir="connectors/common/lib" />
 		<retro7 qjar="edgent.connectors.iot.jar" qdir="connectors/iot/lib" />
 		<retro7 qjar="edgent.connectors.iotp.jar" qdir="connectors/iotp/lib" />
 		<retro7 qjar="edgent.connectors.http.jar" qdir="connectors/http/lib" />
 		<retro7 qjar="edgent.connectors.pubsub.jar"  qdir="connectors/pubsub/lib" />
+        <!-- connectors/command - why not java7? -->
+        <!-- connectors/csv - why not java7? -->
+        <!-- connectors/file - why not java7? -->
+        <!-- connectors/jdbc - why not java7? -->
+        <!-- connectors/mqtt - why not java7? -->
+        <!-- connectors/kafka - why not java7? -->
+        <!-- connectors/wsclient - why not java7? -->
+        <!-- connectors/javax.websocket-client - why not java7? -->
 		<retro7 qjar="edgent.apps.iot.jar"  qdir="apps/iot/lib" />
 		<retro7 qjar="edgent.apps.runtime.jar"  qdir="apps/runtime/lib" />
+        <!-- analytics/math3 - why not java7? -->
+        <!-- analytics/sensors - why not java7? -->
 		<retro7 qjar="edgent.providers.iot.jar" />
 
                 <retro7 qjar="edgent.samples.apps.jar" qdir="samples/lib" />
@@ -138,10 +158,16 @@
 		<copy todir="${edgent7.target}/connectors/iotp/ext">
 			<fileset dir="${edgent8.target}/connectors/iotp/ext"/>
 		</copy>
+        <mkdir dir="${edgent7.target}/connectors/http/ext"/>
+        <copy todir="${edgent7.target}/connectors/http/ext">
+            <fileset dir="${edgent8.target}/connectors/http/ext"/>
+        </copy>
+		<!-- why mqtt/ext when connectors/mqtt not included above? -->
 		<mkdir dir="${edgent7.target}/connectors/mqtt/ext"/>
 		<copy todir="${edgent7.target}/connectors/mqtt/ext">
 			<fileset dir="${edgent8.target}/connectors/mqtt/ext"/>
 		</copy>
+        <!-- why math3/ext when analytics/math3 not included above? -->
 		<mkdir dir="${edgent7.target}/analytics/math3/ext"/>
 		<copy todir="${edgent7.target}/analytics/math3/ext">
 			<fileset dir="${edgent8.target}/analytics/math3/ext"/>
@@ -242,13 +268,25 @@
 		<retro7.test.setup tdir="runtime/jsoncontrol" />
 		<retro7.test.setup tdir="runtime/jobregistry" />
 		<retro7.test.setup tdir="utils/metrics"  ldir="utils/metrics/lib"/>
+        <!-- utils/streamscope - why not java7? -->
 		<retro7.test.setup tdir="providers/direct" />
+        <!-- providers/development - why not java7? -->
 		<retro7.test.setup tdir="connectors/common" ldir="connectors/common/lib"/>
 		<retro7.test.setup tdir="connectors/iotp"  ldir="connectors/iotp/lib"/>
 		<retro7.test.setup tdir="connectors/http"  ldir="connectors/http/lib"/>
 		<retro7.test.setup tdir="connectors/pubsub"  ldir="connectors/pubsub/lib"/>
+        <!-- connectors/command - why not java7? -->
+        <!-- connectors/csv - why not java7? -->
+        <!-- connectors/file - why not java7? -->
+        <!-- connectors/jdbc - why not java7? -->
+        <!-- connectors/mqtt - why not java7? -->
+        <!-- connectors/kafka - why not java7? -->
+        <!-- connectors/wsclient - why not java7? -->
+        <!-- connectors/javax.websocket-client - why not java7? -->
 		<retro7.test.setup tdir="apps/iot"  ldir="apps/iot/lib"/>
 		<retro7.test.setup tdir="apps/runtime"  ldir="apps/runtime/lib"/>
+        <!-- analytics/math3 - why not java7? -->
+        <!-- analytics/sensors - why not java7? -->
 	</target>
 
         <!--
@@ -272,13 +310,25 @@
 		<retro7.test.run tdir="runtime/jsoncontrol" />
 		<retro7.test.run tdir="runtime/jobregistry" />
 		<retro7.test.run tdir="utils/metrics"  ldir="utils/metrics/lib"/>
+        <!-- utils/streamscope - why not java7? -->
 		<retro7.test.run tdir="providers/direct" />
+        <!-- providers/development - why not java7? -->
 		<retro7.test.run tdir="connectors/common" ldir="connectors/common/lib"/>
 		<retro7.test.run tdir="connectors/iotp"  ldir="connectors/iotp/lib"/>
 		<retro7.test.run tdir="connectors/http"  ldir="connectors/http/lib"/>
 		<retro7.test.run tdir="connectors/pubsub"  ldir="connectors/pubsub/lib"/>
+        <!-- connectors/command - why not java7? -->
+        <!-- connectors/csv - why not java7? -->
+        <!-- connectors/file - why not java7? -->
+        <!-- connectors/jdbc - why not java7? -->
+        <!-- connectors/mqtt - why not java7? -->
+        <!-- connectors/kafka - why not java7? -->
+        <!-- connectors/wsclient - why not java7? -->
+        <!-- connectors/javax.websocket-client - why not java7? -->
 		<retro7.test.run tdir="apps/iot"  ldir="apps/iot/lib"/>
 		<retro7.test.run tdir="apps/runtime"  ldir="apps/runtime/lib"/>
+        <!-- analytics/math3 - why not java7? -->
+        <!-- analytics/sensors - why not java7? -->
 	</target>
 
 	<target name="clean">

--- a/providers/direct/build.gradle
+++ b/providers/direct/build.gradle
@@ -18,7 +18,7 @@ dependencies {
   compile project(':runtime:appservice')
   compile project(':runtime:etiao')
   compile project(':runtime:jsoncontrol')
-  compile ext_classpath
+  compile core_ext_dependencies
   testCompile project(':utils:metrics')
   testCompile project(':runtime:appservice')
 }

--- a/runtime/appservice/build.gradle
+++ b/runtime/appservice/build.gradle
@@ -14,5 +14,5 @@
 dependencies {
   compile project(':api:execution')
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/runtime/etiao/build.gradle
+++ b/runtime/etiao/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile project(':api:execution')
   compile project(':api:graph')
   compile project(':spi:graph')
-  compile ext_classpath
+  compile core_ext_dependencies
 }
 
 addCompileTestDependencies ':api:graph'

--- a/runtime/jmxcontrol/build.gradle
+++ b/runtime/jmxcontrol/build.gradle
@@ -14,5 +14,5 @@
 dependencies {
   compile project(':api:execution')
   compile project(':api:function')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/runtime/jobregistry/build.gradle
+++ b/runtime/jobregistry/build.gradle
@@ -14,5 +14,5 @@
 dependencies {
   compile project(':api:execution')
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/runtime/jsoncontrol/build.gradle
+++ b/runtime/jsoncontrol/build.gradle
@@ -14,5 +14,5 @@
 dependencies {
   compile project(':api:execution')
   compile project(':api:function')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/samples/apps/build.gradle
+++ b/samples/apps/build.gradle
@@ -20,5 +20,7 @@ dependencies {
   compile project(':analytics:math3')
   compile project(':analytics:sensors')
   compile project(':samples:utils')
-  compile ext_classpath
+  compile core_ext_dependencies
+  
+  runtime samples_ext_dependencies
 }

--- a/samples/connectors/build.gradle
+++ b/samples/connectors/build.gradle
@@ -22,5 +22,7 @@ dependencies {
   compile project(':connectors:serial')
   compile project(':samples:topology')
   compile project(':samples:utils')
-  compile ext_classpath
+  compile core_ext_dependencies
+  
+  runtime samples_ext_dependencies
 }

--- a/samples/console/build.gradle
+++ b/samples/console/build.gradle
@@ -15,5 +15,7 @@ dependencies {
   compile project(':providers:development')
   compile project(':providers:direct')
   compile project(':console:server')
-  compile ext_classpath
+  compile core_ext_dependencies
+  
+  runtime samples_ext_dependencies
 }

--- a/samples/scenarios/build.gradle
+++ b/samples/scenarios/build.gradle
@@ -18,5 +18,7 @@ dependencies {
   compile project(':providers:iot')
   compile project(':connectors:iotp')
   compile 'com.pi4j:pi4j-core:1.0'
-  compile ext_classpath
+  compile core_ext_dependencies
+  
+  runtime samples_ext_dependencies
 }

--- a/samples/topology/build.gradle
+++ b/samples/topology/build.gradle
@@ -17,5 +17,7 @@ dependencies {
   compile project(':analytics:math3')
   compile project(':runtime:jobregistry')
   compile project(':samples:utils')
-  compile ext_classpath
+  compile core_ext_dependencies
+  
+  runtime samples_ext_dependencies
 }

--- a/samples/utils/build.gradle
+++ b/samples/utils/build.gradle
@@ -17,5 +17,7 @@ dependencies {
   compile project(':utils:metrics')
   compile project(':analytics:math3')
   compile project(':analytics:sensors')
-  compile ext_classpath
+  compile core_ext_dependencies
+  
+  runtime samples_ext_dependencies
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -64,5 +64,7 @@ include 'samples:console'
 include 'samples:scenarios'
 include 'test:fvtiot'
 include 'test:svt'
+include 'platform:java7'
+include 'platform:android'
 
 rootProject.name = build_name

--- a/spi/graph/build.gradle
+++ b/spi/graph/build.gradle
@@ -14,5 +14,5 @@
 dependencies {
   compile project(':api:execution')
   compile project(':api:graph')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/spi/topology/build.gradle
+++ b/spi/topology/build.gradle
@@ -13,5 +13,5 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
 }

--- a/test/fvtiot/build.gradle
+++ b/test/fvtiot/build.gradle
@@ -15,7 +15,7 @@ dependencies {
   compile project(':providers:iot')
   compile project(':runtime:appservice')
   compile project(':runtime:jsoncontrol')
-  compile ext_classpath
+  compile core_ext_dependencies
 }
 
 addCompileTestDependencies ':apps:iot'

--- a/test/svt/build.gradle
+++ b/test/svt/build.gradle
@@ -20,7 +20,7 @@ dependencies {
   compile project(':providers:development')
   compile project(':samples:apps')
   compile project(':connectors:iotp')
-  compile ext_classpath
+  compile core_ext_dependencies
 }
 
 tasks.build.doFirst(){

--- a/utils/metrics/build.gradle
+++ b/utils/metrics/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
 }
 
 addCompileTestDependencies ':api:topology'

--- a/utils/streamscope/build.gradle
+++ b/utils/streamscope/build.gradle
@@ -13,7 +13,7 @@
  */
 dependencies {
   compile project(':api:topology')
-  compile ext_classpath
+  compile core_ext_dependencies
 }
 
 addCompileTestDependencies ':api:topology'


### PR DESCRIPTION
- add building of edgent jar's manifest classpath
- add staging of projects' external dependencies (from maven cache) to target-dir
- add building/staging of java7 and android targets
- fixed a bug where java7 included the http connector but wasn't capturing the connector's external dependencies
- updated JAVA_SUPPORT.md and DEVELOPMENT.md

java8 samples now run from release-dir/tgz.
java7and android target dirs have the appropriate content

There are some staging/tgz differences vs ant script generated tgz:
- Staging of external jars is now flattened in "ext" dirs.  With ant we had somewhat inconsistent and arbitrary intermediate dirs due to the way we happened to add ext jars to our git repo.  e.g., ext/gson-2.2.4.jar vs ext/google-gson-2.2.4/gson-2.2.4.jar
- Some different ext jars are staged. With gradle we stage a declared external dependency's transitive dependencies as known to an external maven repository. With ant we only staged whatever we had manually added to our git repo.  Observed differences in:
  - connectors/http - slight version diff
  - connectors/iotp - a worrysome difference is our dependency on watson-iot.jar ends up including a paho-mqtt-SNAPSHOT jar whereas our repo had a non-SNAPSHOT version
  - connectors/javax.websocket-server - lots of extra things. the tgz shouldn't be including this project
  - connectors/kafka - now has several extra jars
- gradle (correctly I think) doesn't stage ./console/servlets/lib/edgent.console.servlets.jar.  Everything is in the console.war.  Running a 'development provider' sample from a gradle generated tgz works fine wrt running a Console against the job.
- gradle (correctly I think) doesn't include connectors/javax.websocket-server in the tgz (fyi, that project includes lots of additional transitive ext jars vs ant)

TODOs (post-merge)
- task that runs all edgent tests against the jars (as ant build's "test" does)
- testing of java7,android targets
- building of android/{hardware,topology}
- figure out what's needed for notice/license info for external jars copied into tgz
- the paho-mqtt-SNAPSHOT thing