### PR TITLE
Edgent-247 fix android/{hardware,topology} ant build

### DIFF
--- a/android/hardware/src/main/java/org/apache/edgent/android/hardware/SensorStreams.java
+++ b/android/hardware/src/main/java/org/apache/edgent/android/hardware/SensorStreams.java
@@ -21,9 +21,9 @@ package org.apache.edgent.android.hardware;
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorManager;
-import edgent.android.hardware.runtime.SensorSourceSetup;
-import edgent.topology.TStream;
-import edgent.topology.TopologyElement;
+import org.apache.edgent.android.hardware.runtime.SensorSourceSetup;
+import org.apache.edgent.topology.TStream;
+import org.apache.edgent.topology.TopologyElement;
 
 /**
  * Create streams from sensors.

--- a/android/hardware/src/main/java/org/apache/edgent/android/hardware/runtime/SensorChangeEvents.java
+++ b/android/hardware/src/main/java/org/apache/edgent/android/hardware/runtime/SensorChangeEvents.java
@@ -22,7 +22,7 @@ import android.hardware.Sensor;
 import android.hardware.SensorEvent;
 import android.hardware.SensorEventListener;
 
-import edgent.function.Consumer;
+import org.apache.edgent.function.Consumer;
 
 /**
  * Sensor event listener that submits sensor

--- a/android/hardware/src/main/java/org/apache/edgent/android/hardware/runtime/SensorSourceSetup.java
+++ b/android/hardware/src/main/java/org/apache/edgent/android/hardware/runtime/SensorSourceSetup.java
@@ -18,7 +18,7 @@ under the License.
 */
 package org.apache.edgent.android.hardware.runtime;
 
-import edgent.function.Consumer;
+import org.apache.edgent.function.Consumer;
 
 import android.hardware.Sensor;
 import android.hardware.SensorEvent;

--- a/android/topology/build.xml
+++ b/android/topology/build.xml
@@ -29,6 +29,7 @@
 
   <path id="compile.classpath">
     <pathelement location="${edgent.lib}/edgent.api.topology.jar" />
+    <pathelement location="${edgent.lib}/edgent.api.oplet.jar" />
   </path>
 
 

--- a/android/topology/src/main/java/org/apache/edgent/android/oplet/RunOnUIThread.java
+++ b/android/topology/src/main/java/org/apache/edgent/android/oplet/RunOnUIThread.java
@@ -19,7 +19,7 @@ under the License.
 package org.apache.edgent.android.oplet;
 
 import android.app.Activity;
-import edgent.oplet.core.Pipe;
+import org.apache.edgent.oplet.core.Pipe;
 
 public class RunOnUIThread<T> extends Pipe<T,T> {
 

--- a/android/topology/src/main/java/org/apache/edgent/android/topology/ActivityStreams.java
+++ b/android/topology/src/main/java/org/apache/edgent/android/topology/ActivityStreams.java
@@ -19,12 +19,12 @@ under the License.
 package org.apache.edgent.android.topology;
 
 import android.app.Activity;
-import edgent.android.oplet.RunOnUIThread;
-import edgent.function.Consumer;
-import edgent.function.Function;
-import edgent.topology.TSink;
-import edgent.topology.TStream;
-import edgent.topology.plumbing.PlumbingStreams;
+import org.apache.edgent.android.oplet.RunOnUIThread;
+import org.apache.edgent.function.Consumer;
+import org.apache.edgent.function.Function;
+import org.apache.edgent.topology.TSink;
+import org.apache.edgent.topology.TStream;
+import org.apache.edgent.topology.plumbing.PlumbingStreams;
 
 /**
  * Stream utilities for an Android {@code Activity}.


### PR DESCRIPTION
- fix bug in android/topology/build.xml -- missing oplet jar presumably
from earlier refactoring
- fix bugs in android/{hardware,topology} classes -- import names from
quarks->edgent rename.

Need to "ant release" with ANDROID_SDK_PLATFORM ev set to see thebuild
problems in the absence of these changes.