### PR TITLE
Edgent-240 [gradle] Overhaul dependency specification and handling

### DIFF
--- a/analytics/math3/build.gradle
+++ b/analytics/math3/build.gradle
@@ -12,10 +12,12 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile 'org.apache.commons:commons-math3:3.4.1'
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addProjectExtDependency 'compile', 'org.apache.commons:commons-math3:3.4.1'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/analytics/sensors/build.gradle
+++ b/analytics/sensors/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/android/hardware/build.gradle
+++ b/android/hardware/build.gradle
@@ -16,8 +16,10 @@
 // based on System.env.ANDROID_SDK_PLATFORM
 
 dependencies {
-  compile project(':api:topology')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
   compile files("${System.env.ANDROID_SDK_PLATFORM}/android.jar")
+  
+  // N.B. root project adds test common dependencies
 }
 
 test {

--- a/android/topology/build.gradle
+++ b/android/topology/build.gradle
@@ -16,9 +16,11 @@
 // based on System.env.ANDROID_SDK_PLATFORM
 
 dependencies {
-  compile project(':api:topology')
-  compile project(':api:oplet')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':api:oplet'
   compile files("${System.env.ANDROID_SDK_PLATFORM}/android.jar")
+
+  // N.B. root project adds test common dependencies
 }
 
 test {

--- a/api/execution/build.gradle
+++ b/api/execution/build.gradle
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:function')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:function'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/api/function/build.gradle
+++ b/api/function/build.gradle
@@ -11,6 +11,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 dependencies {
-  compile core_ext_dependencies
+  // none
+
+  // N.B. root project adds test common dependencies
 }

--- a/api/graph/build.gradle
+++ b/api/graph/build.gradle
@@ -12,8 +12,10 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:oplet')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:oplet'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }
 
 test {

--- a/api/oplet/build.gradle
+++ b/api/oplet/build.gradle
@@ -12,8 +12,10 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:function')
-  compile project(':api:execution')
-  compile project(':api:window')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:function'
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:window'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/api/topology/build.gradle
+++ b/api/topology/build.gradle
@@ -12,10 +12,13 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:execution')
-  compile project(':api:graph')
-  compile project(':api:oplet')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:function'
+  addTargetDirProjectJarDependency 'compile', ':api:graph'
+  addTargetDirProjectJarDependency 'compile', ':api:oplet'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }
 
 //Build a jar file containing the applications to test the ApplicationService

--- a/api/window/build.gradle
+++ b/api/window/build.gradle
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:function')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:function'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/apps/iot/build.gradle
+++ b/apps/iot/build.gradle
@@ -12,8 +12,10 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile project(':connectors:pubsub')
-  compile project(':connectors:iot')
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':connectors:pubsub'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iot'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }

--- a/apps/runtime/build.gradle
+++ b/apps/runtime/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile project(':runtime:jobregistry')
-  compile project(':runtime:appservice')
-  testCompile project(':providers:direct')
-  testCompile project(':runtime:jmxcontrol')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':runtime:jobregistry'
+  addTargetDirProjectJarDependency 'compile', ':runtime:appservice'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  addTargetDirProjectJarDependency 'testCompile', ':runtime:jmxcontrol'
+  // N.B. root project adds test common dependencies
 }

--- a/build.gradle
+++ b/build.gradle
@@ -21,11 +21,6 @@ allprojects {
 
   repositories {
     mavenCentral()
-    maven {
-      // TODO - is this the right repo to use?
-      // related?... watson-iot-0.1.1.jar ends up referencing org.eclipse.paho.client.mqttv3-1.0.3-SNAPSHOT.jar
-      url 'https://repo.eclipse.org/content/repositories/paho-snapshots/'
-    }
   }
   
   project.version = build_version
@@ -78,41 +73,33 @@ ext {
     project -> !aggregatorOnlyProjects.contains(project.path)
   }
   
-  // for manifest classpath hackery
-  jarNameToProjectMap = [:]  // e.g., "edgent.connectors.iotp-0.4.0.jar" => Project(':component:iotp')
-  projectToJarNameMap = [:]
-  
   // Edgent core external dependencies
   core_ext_dependencies = ['com.google.code.gson:gson:2.2.4',
                    'org.slf4j:slf4j-api:1.7.12',
                    'io.dropwizard.metrics:metrics-core:3.1.2']
-  copied_core_ext_dependencies_jars = false
   
   // Edgent Samples external dependencies
   samples_ext_dependencies = ['org.slf4j:slf4j-jdk14:1.7.12']
-  copied_samples_ext_dependencies_jars = false
 
   // Edgent tests external dependencies
-  tests_ext_dependencies = ['org.slf4j:slf4j-jdk14:1.7.12']
-  copied_tests_ext_dependencies_jars = false
+  test_common_dependencies = ['org.slf4j:slf4j-jdk14:1.7.12']
   
   common_ext_dependencies = [
     core_ext_dependencies,
     samples_ext_dependencies,
-    // tests_ext_dependencies, // omit as tests aren't included in release tgz
+    // test_common_dependencies, // omit as tests aren't included in release tgz
   ].flatten()
 }
 
-def recordProjectJar(Project proj) {
-  // manifest classpath hackery: update maps of project's jar <=> Project
-  // This, and use of these maps, is fallout from floundering
-  // trying to leverage the gradle object model for dealing with
-  // project (and dependent project) artifacts and/or other nice
-  // gradle declaritive-isms for dealing with this.
-  def jarName = "${proj.group}.${proj.name}-${project.version}.jar"
-  jarNameToProjectMap[jarName] = proj
-  projectToJarNameMap[proj] = jarName
-  //println "#### $proj.path updated jar <=> project maps: $jarName"
+// Declare the common_ext_dependencies as dependencies of the root project
+// to easily copy them (their resolved paths) to the target dir
+dependencies {
+  compile common_ext_dependencies
+}
+task copyCommonExtJars(type: Copy) {
+  description = "Copy common external jars to target_java8_ext_dir"
+  from configurations.compile.files
+  into target_java8_ext_dir
 }
 
 def String mkJarNameFromSpec(String jarSpec) {
@@ -120,90 +107,15 @@ def String mkJarNameFromSpec(String jarSpec) {
   return jarSpec.split(':')[1] + '-' + jarSpec.split(':')[2] + '.jar'
 }
 
-def String stripJarNameVersion(String jarName) {
-  // e.g., edgent.api.topology-0.4.0.jar => edgent.api.topology.jar
-  return jarName.substring(0, jarName.lastIndexOf('-')) + '.jar'
-}
-
-def String getSimpleProjectGroup(Project proj) {
-  // e.g., 'edgent.api' => 'api'
-  return "$proj.group".replace("edgent.", "")
-}
-
-// create a path to dir2 relative to dir1
-// e.g., dir1:'lib', dir2:'connectors/iotp/lib' => ../connectors/iotp/lib
-def String mkRelativePath(File dir1, File dir2) {
-  def relPath = dir1.toPath().relativize(dir2.toPath())
-  //println "#### relPath: "+relPath+"   dir1:"+dir1+" dir2:"+dir2
-  return relPath.toString()
-}
-def String mkRelativePath(String dir1, String dir2) {
-  return mkRelativePath(new File(dir1), new File(dir2))
-}
-
-// e.g., =>  "lib" or "<component>/<subcomponent>/lib"
-def String getTargetRelProjDir(Project proj, String kind) {  // kind: "lib", "ext"
-  // the general case location
-  def simpleProjectGroup = getSimpleProjectGroup(proj);
-  def relProjDir = "$simpleProjectGroup/$proj.name/$kind"
-   
-  // special cases
-  if (target_java8_lib_groups.contains(simpleProjectGroup)) {
-    relProjDir = "$kind"
-  }
-  else if ('samples' == simpleProjectGroup) {
-    relProjDir = "$simpleProjectGroup/$kind"
-  }
-   
-  return relProjDir
-}
-
-// Get paths relative to the project's dir in the target-dir
-// to the project's immediate-only dependant project's jars
-// in their project's dir in the target dir
-// 
-// e.g., returns ['../../../lib/edgent.api.topology.jar', ...]
-def Collection getTargetRelDirectDependantProjJars(Project proj) {
-
-  def directDependantProjects = proj.configurations.compile.dependencies
-            .withType(ProjectDependency.class)
-            .collect { it.dependencyProject }
-  //println "#### $proj.path directDependantProjects: $directDependantProjects"
-  
-  def directDependantProjJars = directDependantProjects.collect {
-    def relProjDirInTarget = getTargetRelProjDir(it, 'lib')
-    def jarName = projectToJarNameMap[it]
-    "$relProjDirInTarget/$jarName"
-  }
-  
-  // make relative paths from the project's dir in targetDir to the
-  // jars in the dependent projects' dir in targetDir
-  def myProjDirInTargetDir = getTargetRelProjDir(proj, 'lib')
-  def relDependantJars = directDependantProjJars.collect {
-    mkRelativePath(myProjDirInTargetDir, it)
-  }
-  //println "#### $proj.path relDependantJars: $relDependantJars"
-  return relDependantJars
-}
-
-// e.g., returns ['../../../ext/gson-2.2.4.jar', ...]
-def Collection getTargetRelDependantCommonExtJars(Project proj, Collection ext_dependencies) {
-  // make relative paths from the project's dir in targetDir to the
-  // "ext" dir in targetDir (target_java8_ext_dir)
-  def myProjDirInTargetDir = getTargetRelProjDir(proj, 'lib')
-  def relDependantJars = ext_dependencies.collect {
-    jarSpec ->
-      def jarName = mkJarNameFromSpec jarSpec
-      def relativeDependantJarDir = mkRelativePath(myProjDirInTargetDir, 'ext')
-      "$relativeDependantJarDir/$jarName"
-  }
-  //println "#### $proj.path relDependantJars: $relDependantJars"
-  return relDependantJars
-}
-
 def getProjectExtDepFiles(Project proj) { // project's direct ext deps and their transitive deps
   // TODO suspect this is picking up ext dependencies of transitive **project** dependencies???
+  
+  // handle ext jar deps expressed via "compile <external-dependency-spec>"
   def allExtDepFiles = proj.configurations.runtime.files { it instanceof ExternalDependency }
+  
+  // handle ext jar deps expressed via addTargetDirExtJarDependency
+  allExtDepFiles.addAll proj.files(proj.directTargetDirExtJarDependencies)
+  
   logger.info "$proj.path allExtDepFiles: "+allExtDepFiles
   return allExtDepFiles
 }
@@ -219,58 +131,34 @@ def getProjectNonCommonExtDepFiles(Project proj) {
   return filteredExtDepFiles
 }
 
-// Get paths relative to the project's lib dir in the target-dir
-// to the project's immediate external jar dependencies (and their dependencies
-// transitively) in the project's ext dir in the target dir
-//
-// Should NOT include any external dependencies from the project's dependant *projects* (transitively)
-// TODO fix that
-// 
-// e.g., returns ['../ext/jetty-...', ...]
-def Collection getTargetRelDependantProjExtJars(Project proj) {
-  def myProjLibDirInTargetDir = getTargetRelProjDir(proj, 'lib')
-  def myProjExtDirInTargetDir = getTargetRelProjDir(proj, 'ext')
-  def relProjExtDirPath = mkRelativePath(myProjLibDirInTargetDir, myProjExtDirInTargetDir)
-    
-  // assumes updateTargetDir task copies all the project's ext dependencies
-  // to <projectDirInTarget>/ext
-  
-  def relProjExtDeps = getProjectNonCommonExtDepFiles(proj).collect {
-    file -> "$relProjExtDirPath/$file.name"
-  }
-  //println "#### $proj.path relProjExtDeps: $relProjExtDeps"
-  return relProjExtDeps
-}
-
 def String mkManifestClassPath(Project proj) {
   // The manifest's classpath needs to include the project's:
-  // - immediate-only dependant edgent jars (not transitive and not their ext deps)
-  // - "other" dependant external jars - e.g., samples_ext_dependencies
-  // - immediate dependant external jars and their transitive deps
-  // - the core_ext_dependencies jars
-  
-  def depProjJars = getTargetRelDirectDependantProjJars proj
-  depProjJars = depProjJars.collect { stripJarNameVersion it }
-  
-  def projExtJars = getTargetRelDependantProjExtJars proj
-  
-  // unfortunate to include these if project didn't declare them as a dependency
-  def coreExtJars = getTargetRelDependantCommonExtJars(proj, core_ext_dependencies)
-  
-  def otherExtJars = []
-  if (proj.path ==~ '^:samples.*') {
-     otherExtJars.addAll getTargetRelDependantCommonExtJars(proj, samples_ext_dependencies)
+  // - immediate-only dependant edgent jars (not transitive and not their ext deps
+  //   since our project jars are build with a manifest-classpath that
+  //   handles the project's "private" dependencies)
+  // - immediate dependant external jars and their transitive deps (since
+  //   these don't seem to have a manifest classpath that takes care of their
+  //   dependencies)
+  // - common_ext_dependencies jars when declared as dependencies
+  //
+  // proj.configurations.runtime.files (mostly) captures all of the above
+  // since do to our project build.gradle use of our various add*Dependency().
+
+  def depJars = proj.configurations.runtime.files
+    
+  // assume that any deps still in the gradle cache are project private ext deps
+  // (that will-get/have-been copied into the project's ext dir in the targetdir) 
+  def projExtDir = "$target_java8_dir/$proj.targetRelProjExtDir"
+  depJars = depJars.collect { file ->
+    if (file.toString().contains('/.gradle/caches/')) {
+      return proj.file("$projExtDir/"+file.getName())
+    }
+    return file
   }
     
-  def jars = []
-  jars.addAll depProjJars
-  jars.addAll otherExtJars
-  jars.addAll projExtJars
-  jars.addAll coreExtJars
-    
-  def classPathStr = jars.join(' ')
-  //println "#### $proj.path manifest-classPath: $classPathStr"
-  return classPathStr
+  def cp = proj.mkRelativePaths(depJars).join(' ')
+  logger.info "$proj.path manifest-classPath: $cp"
+  return cp
 }
 
 gradle.taskGraph.whenReady {taskGraph ->
@@ -303,22 +191,116 @@ subprojects {
     return
   }
   
-  assemble { // in configure phase...
-    recordProjectJar(project)
+  ext.simpleGroupName = project.group.replace('edgent.', '') // e.g., 'edgent.api' => 'api'
+
+  ext.mkRelativePaths = { Collection files ->
+    // make all files paths relative to the project's lib dir in targetdir
+    // well... unless this is for a war, which resides in the group's "webapps"
+    // dir instead of project's lib dir.  See :console:servlets build.gradle.
+    def projLibDir = project.file("$target_java8_dir/$targetRelProjLibDir")
+    if (project.pluginManager.hasPlugin('war')) {
+      projLibDir = project.file("$target_java8_dir/$project.simpleGroupName/webapps")
+    }
+    files.collect {  projLibDir.toPath().relativize(it.toPath()) }
   }
 
-  if (["javax.websocket-client", "javax.websocket-server", "edgent.javax.websocket"].contains(project.name)) {
-    archivesBaseName = "${project.name}"
-  } else {
-    archivesBaseName = "${rootProject.name}${project.path.replace(':', '.')}"
+  ext.targetRelProjDir = { String kind ->  // kind: "lib", "ext"
+    // use targetRelProject{Lib,Ext}Dir
+    // e.g., =>  "lib" or "<component>/<subcomponent>/lib"
+    // the general case location
+    def relProjDir = "$simpleGroupName/$project.name/$kind"
+   
+    // special cases
+    if (target_java8_lib_groups.contains(simpleGroupName)) {
+      relProjDir = "$kind"
+    }
+    else if ('samples' == simpleGroupName) {
+      relProjDir = "samples/$kind"
+    }
+   
+    return relProjDir
+  }
+  ext.targetRelProjLibDir = targetRelProjDir('lib')
+  ext.targetRelProjExtDir = targetRelProjDir('ext')
+  
+  // N.B. regarding the various add*Dependency() methods
+  //
+  // The methods need to be used in project build.gradle "dependencies" declarations.
+  // e.g.,
+  //   dependencies {
+  //     addTargetDirProjectJarDependency 'compile', ':api:topology' # NOT compile project(':api:topology')
+  //     addProjectExtDependency 'compile', 'com.ibm.messaging:watson-iot:0.1.5'  # NOT compile 'com.ibm.messaging:watson-iot:0.1.5'
+  //     addProjectExtDependency 'compile', 'org.apache.kafka:kafka_2.10:0.8.2.2@jar'
+  //     addTargetDirCoreExtDependencies 'compile'
+  //     addMyTargetDirProjectJarDependency 'testCompile'
+  //     // N.B. root project adds test common dependencies
+  //   }
+  // 
+  // These methods play a role in the policies:
+  // - Edgent projects depend on other project's jars in the target-dir, not their classes
+  // - Edgent project jars have a manifest-classpath that handles
+  //   the project's "private" inter-project dependencies
+  //   as well as the project's "private" external component dependencies.
+  // - We build a target dir that includes the project's jar as well as
+  //   the project's external dependency jars
+  // - The tests compile and run against the project jars in the target dir
+  //   (as external/integration test code would).
+  // - The samples compile and run against the project jars in the target dir
+  //   (as user code would).
+  
+  ext.directTargetDirExtJarDependencies = [] 
+
+  ext.addTargetDirProjectJarDependency = { config,proj ->
+    // add a dependency on a project's jar in the target-dir
+    def jarPath = project(proj).jar.archivePath
+    
+    // add the jar as a dependency and ensure it's present when we need it
+    // ? script error with: dependencies { "$config" files(jarPath) builtBy "${proj}:assemble" }
+    dependencies { "$config" files(jarPath) }
+    def task = "${config}Java"
+    if (config == "testCompile") {
+      task = "compileTestJava"
+    }
+    else if (config == "providedCompile") {
+      task = "compileJava"
+    }
+    "$task" { dependsOn "${proj}:assemble" }
   }
 
-  dependencies {
-    testCompile 'junit:junit:4.10'
-    testRuntime 'org.slf4j:slf4j-jdk14:1.7.12'
+  ext.addMyTargetDirProjectJarDependency = { config ->
+    // add a dependency on my project's jar in the target dir
+    addTargetDirProjectJarDependency(config, project.path)
+  }
+  
+  ext.addTargetDirExtJarDependency = { config,jarName ->
+    // add a dependency on a target_java8_ext_dir jarName
+    // record the addition
+    def jar = "$target_java8_ext_dir/$jarName"
+    if (!directTargetDirExtJarDependencies.contains(jar)) {
+      directTargetDirExtJarDependencies.add jar
+    }
+    
+    // add the jar as a dependency
+    dependencies { "$config" files(jar) }
+    compileJava { dependsOn ':copyCommonExtJars' }
+  }
+  
+  ext.addTargetDirCoreExtJarDependencies = { config ->
+    core_ext_dependencies.collect { depSpec ->
+      mkJarNameFromSpec(depSpec)
+    }.each { jarName ->
+      addTargetDirExtJarDependency config, jarName
+    }
+  }
+
+  ext.addProjectExtDependency = { config,externalDepSpec ->
+    // for declaring project private external dependencies
+    // ends up (transitively) copying the dependency to the project's ext dir
+    dependencies { "$config" externalDepSpec }
   }
 
   ext.addCompileTestDependencies = { String... deps ->
+    // add a dependency on other project's testClasses
     deps.each { dep ->
       dependencies {
         testCompile project(dep).sourceSets.test.output
@@ -347,13 +329,6 @@ subprojects {
   }
 
   test {
-    // TODO fix this - this dependency handling shouldn't occur here,
-    // rather :console:server should dependOn :console:servlets
-    // (really the server doesn't exist w/o the servlets)
-    if(it.path == ":test:fvtiot" ||  it.path == ":providers:development") {
-      dependsOn ":console:servlets"
-    }
-    
     filter {
       includeTestsMatching '*Test'  // can override via --tests command line option
     }
@@ -368,18 +343,79 @@ subprojects {
       html.enabled = true
     }
   }
+  
+  dependencies {
+    // common dependencies for tests
+    testCompile 'junit:junit:4.10'
+    addMyTargetDirProjectJarDependency 'testCompile'
+    if (project.path != ':api:function') {
+      addTargetDirExtJarDependency 'testRuntime', 'slf4j-jdk14-1.7.12.jar'
+    }
+    else {
+      // the add... induces UnsupportedOperationException elsewhere in script when processing :api:function:jar ???
+      // can't figure it out but cleaning directTargetDirExtJarDependencies
+      // avoids it ???... with seemingly no other consequences.
+      addTargetDirExtJarDependency 'testRuntime', 'slf4j-jdk14-1.7.12.jar'
+      project.directTargetDirExtJarDependencies = []
+    }
+
+    // common dependencies for samples
+    if (project.path ==~ '^:samples.*') {
+      addTargetDirProjectJarDependency 'compile', ':providers:development'
+      addTargetDirProjectJarDependency 'compile', ':providers:direct'
+
+      addTargetDirCoreExtJarDependencies 'compile'      
+      addTargetDirExtJarDependency 'runtime', 'slf4j-jdk14-1.7.12.jar'
+    }
+  }
+
+  jar {
+    // adjust jar task config and also augment the task to do our additional processing
+    
+    // generate the project's jar into the target dir location
+    // with the appropriate name and manifest.
+    // TODO - gradle/maven best practice has version in jarname
+    
+    archiveName = "${project.group}.${project.name}.${extension}"
+    if (["javax.websocket-client", "javax.websocket-server", "edgent.javax.websocket"].contains(project.name)) {
+      archiveName = "${project.name}.${extension}"
+    }
+    destinationDir = file("$target_java8_dir/" + targetRelProjLibDir)
+
+    doFirst {
+      configure jarOptions
+    }
+    
+    doLast {
+      // Copy the project jar's "private" external dependencies (transitively)
+      // into the project's ext dir in the target-dir.
+      
+      // FYI we're getting more transitive ext deps than the ant build
+      // in some cases - e.g., for watson iot we "knew" we only needed a subset
+      // of all watson iot deps known to maven
+      
+      def projectExtDir = targetRelProjExtDir
+      def nonCommonExtFiles = getProjectNonCommonExtDepFiles(project)
+      logger.info "$project.path copying projExtDepFiles jars: "+nonCommonExtFiles.collect { it.getName() }
+      copy {
+        from nonCommonExtFiles
+        includeEmptyDirs = false
+        into "$target_java8_dir/$projectExtDir"
+      }
+    }
+  }
 
   ext.jarOptions = {
     manifest {
       attributes(
-              'Implementation-Title': "${-> baseName}",
-              'Implementation-Vendor': build_vendor,
-              // TODO inclusion of DSTAMP/TSTAMP results in regeneration
-              // of a jar when none of its contents/dependencies have changed.
-              // If possible use a canned DSTAMP/TSTAMP for non-"release" tasks
-              // to make the dev cycle more efficient at the expense of the TSTAMP.
-              'Implementation-Version': "${commithash}-${DSTAMP}-${TSTAMP}",
-              'Class-Path': mkManifestClassPath(project),
+        'Implementation-Title': "${-> baseName}",
+        'Implementation-Vendor': build_vendor,
+        // TODO inclusion of DSTAMP/TSTAMP results in regeneration
+        // of a jar when none of its contents/dependencies have changed.
+        // If possible use a canned DSTAMP/TSTAMP for non-"release" tasks
+        // to make the dev cycle more efficient at the expense of the TSTAMP.
+        'Implementation-Version': "${commithash}-${DSTAMP}-${TSTAMP}",
+        'Class-Path': mkManifestClassPath(project),
       )
     }
     metaInf {
@@ -387,101 +423,17 @@ subprojects {
       from rootProject.file('NOTICE')
     }
   }
-  jar {
-    // TODO fix this - this dependency handling shouldn't occur here,
-    // rather :console:server should dependOn :console:servlets
-    // (really the server doesn't exist w/o the servlets)
-    if(it.path == ":test:fvtiot" ||  it.path == ":providers:development") {
-      dependsOn ":console:servlets"
-    }
-  }
-  jar.doFirst {
-    configure jarOptions
-  }
 
-  task updateTargetDir() {
-    description = "Copy subproject's assembled artifacts to target_dir (implicitly builds jars due to 'from jar')"    
-    doLast {
-      def simpleProjectGroup = getSimpleProjectGroup(project)
-      
-      // Copy the project's jar or war
-      def relProjDirInTarget = getTargetRelProjDir(project, 'lib')
-      if (relProjDirInTarget != null) {
-        if (project.pluginManager.hasPlugin('war')) {
-          copy {
-            from war
-            into "$target_java8_dir/$simpleProjectGroup/webapps"
-          }
-        }
-        else {
-          copy {
-            from jar
-            into "$target_java8_dir/$relProjDirInTarget"
-            rename("$jar.archiveName", "$jar.baseName.$jar.extension")
-          }
-        }
-      }
+  assemble.doLast {
+    // augment assemble with our additional target dir update processing
     
-      // Copy SRC when appropriate
-      if (simpleProjectGroup == 'samples') {
-        copy {
-          from(sourceSets.main.allSource.srcDirs) { include '**/*.java' }
-          into "$target_java8_dir/$simpleProjectGroup/src/$project.name/src/main/java/"
-        }
-      }
-
-      // Copy the project's external dependencies (transitively)
-      // TODO we're getting more transitive ext deps
-      // in some cases - e.g., for watson iot we "knew" we only needed a subset
-      // of all watson iot deps known to maven
-      
-      def projectExtDir = getTargetRelProjDir(project, 'ext')
-      def nonCommonExtFiles = getProjectNonCommonExtDepFiles(project)
-      logger.info "$project.path copying extDepFiles jars: "+nonCommonExtFiles.collect { it.getName() }
-      //println "#### $project.path copying extDepFiles jars: "+nonCommonExtFiles.collect { it.getName() }
+    // Copy SRC into target dir when appropriate
+    if (project.path ==~ '^:samples.*') {
       copy {
-        from nonCommonExtFiles
-        includeEmptyDirs = false
-        into "$target_java8_dir/$projectExtDir"
+        from(sourceSets.main.allSource.srcDirs) { include '**/*.java' }
+        into "$target_java8_dir/$project.simpleGroupName/src/$project.name/src/main/java/"
       }
-    
-      // Copy core_ext_dependencies jars once
-      if (!copied_core_ext_dependencies_jars) {
-        copied_core_ext_dependencies_jars = true
-        def coreExtJarNames = core_ext_dependencies.collect {
-          mkJarNameFromSpec it
-        }
-        def coreExtDeps = getProjectExtDepFiles(project).findAll {
-          coreExtJarNames.contains(it.getName())
-        }
-        logger.info "$project.path copying core_ext_dependencies_jars: "+coreExtDeps.collect { it.getName() }
-        //println "#### $project.path copying core_ext_dependencies_jars: "+coreExtDeps.collect { it.getName() }
-        copy {
-          from coreExtDeps
-          includeEmptyDirs = false
-          into target_java8_ext_dir
-        }
-      }
-
-      // Copy samples_ext_dependencies jars once
-      if ('samples' == simpleProjectGroup && !copied_samples_ext_dependencies_jars) {
-        copied_samples_ext_dependencies_jars = true
-        def samplesExtJarNames = samples_ext_dependencies.collect {
-          mkJarNameFromSpec it
-        }
-        def commonExtDeps = getProjectExtDepFiles(project).findAll {
-          samplesExtJarNames.contains(it.getName())
-        }
-        logger.info "$project.path copying samples_ext_dependencies_jars: "+commonExtDeps.collect { it.getName() }
-        //println "#### $project.path copying samples_ext_dependencies_jars: "+commonExtDeps.collect { it.getName() }
-        copy {
-          from commonExtDeps
-          includeEmptyDirs = false
-          into target_java8_ext_dir
-        }
-      }
-      
-    } // doLast
+    }
   }
   
   task sourceJar(type: Jar) {
@@ -490,7 +442,7 @@ subprojects {
     classifier = 'sources'
   }  
 
-  // support for 'gradle publishToMavanLocal' etc 
+  // support for 'gradle publishToMavenLocal' etc 
   // TODO publishing test.{fvt,svt} and samples ... doesn't seem desirable? e.g., we're excluding test.{fvt,svt} jars from the tgz
   publishing {
     publications {
@@ -508,9 +460,6 @@ subprojects {
       }
     }
   }  
-  
-  // assemble: inject updating target_dir 
-  assemble.finalizedBy updateTargetDir
 }
 
 task copyScripts(type: Copy) {

--- a/build.gradle
+++ b/build.gradle
@@ -677,15 +677,11 @@ task aggregateJavadoc(type: Javadoc) {
     group("Edgent SPI", "org.apache.edgent.topology.spi", "org.apache.edgent.topology.spi.*")
   }
   source subprojects.collect { project -> project.sourceSets.main.allJava }
-  classpath = files(subprojects.collect
-          { project -> project.sourceSets.main.compileClasspath }
-  )
-  // Eliminate implementation packages/classes from the javadoc.
-  // TODO achieve the effect w/o causing warnings from the javadoc run
   exclude "**/edgent/connectors/**/runtime"
   exclude "**/edgent/console"
   exclude "**/edgent/samples/scenarios/iotp/range/sensor"
   exclude "**/android/**"
+  classpath = files(filteredSubprojects.collect { it.jar.archivePath })
   
   // doc-files aren't picked up automatically so get them now.
   doLast {
@@ -753,6 +749,7 @@ task releaseTarGz(type: Tar) {
 assemble {
   description = "Assemble distribution artifacts and populate the target_dir with jars, doc, etc. Like 'build' w/o 'test'"
   dependsOn filteredSubprojects*.assemble, aggregateJavadoc, copyScripts
+  aggregateJavadoc.mustRunAfter filteredSubprojects*.assemble
 }
 
 task all(dependsOn: assemble) {

--- a/build.gradle
+++ b/build.gradle
@@ -426,12 +426,9 @@ subprojects {
       // The project's tests are supposed to run against its target-dir jar.
       // We must remove the project's $buildDir/{classes,resources}/main
       // from the classpath so they're not used.  
-      // To be safe, just remove any project's {classes,resources}/main from
-      // the test classpath. 
 
       classpath = project.sourceSets.test.runtimeClasspath
-      classpath = classpath.filter { ! ( it.path.endsWith("classes/main")
-                                         || it.path.endsWith("resources/main") )} 
+      classpath -= project.sourceSets.main.output
 
       // Hmm... for some reason the classpath (when printed here) also includes
       // the project's src build/libs/ jar and by the default name
@@ -443,7 +440,7 @@ subprojects {
       // Adjust accordingly.
       
       classpath = classpath.filter { ! it.path.startsWith(project.libsDir.path) } 
-      classpath = files(project.jar.archivePath) + classpath  // our jar first
+      classpath = files(project.jar.archivePath) + classpath
       logger.debug "$project.path test.classpath: " + classpath.collect { it.toString() }
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -327,22 +327,6 @@ subprojects {
   compileTestJava {
     configure compileOptions
   }
-
-  test {
-    filter {
-      includeTestsMatching '*Test'  // can override via --tests command line option
-    }
-
-    systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
-    systemProperty 'edgent.test.root.dir', rootProject.projectDir
-    testLogging {
-      exceptionFormat 'full'
-    }
-    reports {
-      junitXml.enabled = true
-      html.enabled = true
-    }
-  }
   
   dependencies {
     // common dependencies for tests
@@ -421,6 +405,46 @@ subprojects {
     metaInf {
       from rootProject.file('LICENSE')
       from rootProject.file('NOTICE')
+    }
+  }
+
+  test {
+    filter {
+      includeTestsMatching '*Test'  // can override via --tests command line option
+    }
+
+    systemProperty 'edgent.test.top.dir.file.path', rootProject.projectDir
+    systemProperty 'edgent.test.root.dir', rootProject.projectDir
+    testLogging {
+      exceptionFormat 'full'
+    }
+    reports {
+      junitXml.enabled = true
+      html.enabled = true
+    }
+    doFirst {
+      // The project's tests are supposed to run against its target-dir jar.
+      // We must remove the project's $buildDir/{classes,resources}/main
+      // from the classpath so they're not used.  
+      // To be safe, just remove any project's {classes,resources}/main from
+      // the test classpath. 
+
+      classpath = project.sourceSets.test.runtimeClasspath
+      classpath = classpath.filter { ! ( it.path.endsWith("classes/main")
+                                         || it.path.endsWith("resources/main") )} 
+
+      // Hmm... for some reason the classpath (when printed here) also includes
+      // the project's src build/libs/ jar and by the default name
+      // (e.g., build/libs/oplets-0.4.1.jar) yet we've configured the jar task
+      // to generate the jar in the target-dir with a different name.  
+      // It also lacks that target-dir jar we added as a dependency 
+      // via addMyTargetDirProjectJarDependency 'testCompile'
+      // ???  
+      // Adjust accordingly.
+      
+      classpath = classpath.filter { ! it.path.startsWith(project.libsDir.path) } 
+      classpath = files(project.jar.archivePath) + classpath  // our jar first
+      logger.debug "$project.path test.classpath: " + classpath.collect { it.toString() }
     }
   }
 

--- a/connectors/command/build.gradle
+++ b/connectors/command/build.gradle
@@ -12,10 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile project(':connectors:common')
-  testCompile project(':providers:direct')
-  testRuntime core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':connectors:common'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/common/build.gradle
+++ b/connectors/common/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/connectors/csv/build.gradle
+++ b/connectors/csv/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/edgent.javax.websocket/build.gradle
+++ b/connectors/edgent.javax.websocket/build.gradle
@@ -14,6 +14,7 @@
 archivesBaseName = project.name
 
 dependencies {
-  compile 'javax.websocket:javax.websocket-api:1.0'
-  testRuntime core_ext_dependencies
+  addProjectExtDependency 'compile', 'javax.websocket:javax.websocket-api:1.0'
+
+  // N.B. root project adds test common dependencies
 }

--- a/connectors/file/build.gradle
+++ b/connectors/file/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/http/build.gradle
+++ b/connectors/http/build.gradle
@@ -12,11 +12,13 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile 'org.apache.httpcomponents:httpclient:4.5.1'
-  compile 'org.apache.httpcomponents:httpcore:4.4.4'
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addProjectExtDependency 'compile', 'org.apache.httpcomponents:httpclient:4.5.1'
+  addProjectExtDependency 'compile', 'org.apache.httpcomponents:httpcore:4.4.4'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/connectors/iot/build.gradle
+++ b/connectors/iot/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/connectors/iotp/build.gradle
+++ b/connectors/iotp/build.gradle
@@ -12,11 +12,13 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile project(':connectors:iot')
-  compile 'com.ibm.messaging:watson-iot:0.1.1'
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iot'
+  addProjectExtDependency 'compile', 'com.ibm.messaging:watson-iot:0.1.5'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/connectors/javax.websocket-client/build.gradle
+++ b/connectors/javax.websocket-client/build.gradle
@@ -14,7 +14,8 @@
 archivesBaseName = project.name
 
 dependencies {
-  compile project(':connectors:edgent.javax.websocket')
-  compile 'org.eclipse.jetty.websocket:javax-websocket-client-impl:9.3.6.v20151106'
-  testRuntime core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':connectors:edgent.javax.websocket'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty.websocket:javax-websocket-client-impl:9.3.6.v20151106'
+  
+  // N.B. root project adds test common dependencies
 }

--- a/connectors/javax.websocket-server/build.gradle
+++ b/connectors/javax.websocket-server/build.gradle
@@ -14,7 +14,8 @@
 archivesBaseName = project.name
 
 dependencies {
-  compile project(':connectors:javax.websocket-client')
-  compile 'org.eclipse.jetty.websocket:javax-websocket-server-impl:9.3.6.v20151106'
-  testRuntime core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':connectors:javax.websocket-client'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty.websocket:javax-websocket-server-impl:9.3.6.v20151106'
+  
+  // N.B. root project adds test common dependencies
 }

--- a/connectors/jdbc/build.gradle
+++ b/connectors/jdbc/build.gradle
@@ -12,10 +12,12 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  
   testCompile files("${System.env.DERBY_HOME}/lib/derby.jar")
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/kafka/build.gradle
+++ b/connectors/kafka/build.gradle
@@ -12,11 +12,32 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile 'org.apache.kafka:kafka_2.10:0.8.2.2'
-  compile 'org.apache.kafka:kafka-clients:0.8.2.2'
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  
+  // The pom for kafka includes dependencies that don't make sense for us.
+  // In at least one case kafka dependencies include a slf4j *implementation* jar
+  // and that conflicts with our samples' binding to a particular
+  // version of slf4j implementation.
+  // This all seems like fallout from, I believe, the kafka jars containing
+  // the code for their cli tools too, and possibly tests, which need things like:
+  //   slf4j-log4j12, snappy-java, jline, jopt-simple, junit-3.8.1
+  //
+  // So at least for now, avoid transitive and just match our ant based config
+  //
+  // addProjectExtDependency 'compile', 'org.apache.kafka:kafka_2.10:0.8.2.2'
+  // addProjectExtDependency 'compile', 'org.apache.kafka:kafka-clients:0.8.2.2'
+  addProjectExtDependency 'compile', 'org.apache.kafka:kafka_2.10:0.8.2.2@jar'
+  addProjectExtDependency 'compile', 'org.apache.kafka:kafka-clients:0.8.2.2@jar'
+  addProjectExtDependency 'compile', 'log4j:log4j:1.2.16@jar'
+  addProjectExtDependency 'compile', 'com.yammer.metrics:metrics-core:2.2.0@jar'
+  addProjectExtDependency 'compile', 'org.scala-lang:scala-library:2.10.4@jar'
+  addProjectExtDependency 'compile', 'com.101tec:zkclient:0.3@jar'
+  addProjectExtDependency 'compile', 'org.apache.zookeeper:zookeeper:3.4.6@jar'
+  
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/mqtt/build.gradle
+++ b/connectors/mqtt/build.gradle
@@ -12,12 +12,13 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile project(':connectors:iot')
-  compile project(':connectors:common')
-  compile 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.2'
-  testCompile project(':providers:direct')
-  testRuntime core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iot'
+  addTargetDirProjectJarDependency 'compile', ':connectors:common'
+  addProjectExtDependency 'compile', 'org.eclipse.paho:org.eclipse.paho.client.mqttv3:1.0.2'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/pubsub/build.gradle
+++ b/connectors/pubsub/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/connectors/serial/build.gradle
+++ b/connectors/serial/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/connectors/wsclient-javax.websocket/build.gradle
+++ b/connectors/wsclient-javax.websocket/build.gradle
@@ -12,14 +12,16 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile project(':connectors:common')
-  compile project(':connectors:wsclient')
-  compile project(':connectors:edgent.javax.websocket')
-  testCompile project(':providers:direct')
-  testCompile project(':connectors:javax.websocket-client')
-  testCompile project(':connectors:javax.websocket-server')
-  testRuntime core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':connectors:common'
+  addTargetDirProjectJarDependency 'compile', ':connectors:wsclient'
+  addTargetDirProjectJarDependency 'compile', ':connectors:edgent.javax.websocket'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  addTargetDirProjectJarDependency 'testCompile', ':connectors:javax.websocket-client'
+  addTargetDirProjectJarDependency 'testCompile', ':connectors:javax.websocket-server'
+  
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct', ':connectors:common'

--- a/connectors/wsclient/build.gradle
+++ b/connectors/wsclient/build.gradle
@@ -12,9 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
-  testCompile project(':providers:direct')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  addTargetDirProjectJarDependency 'testCompile', ':providers:direct'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':providers:direct'

--- a/console/server/build.gradle
+++ b/console/server/build.gradle
@@ -12,13 +12,17 @@
  * limitations under the License.
  */
 dependencies {
-  compile 'org.eclipse.jetty:jetty-http:9.3.6.v20151106'
-  compile 'org.eclipse.jetty:jetty-io:9.3.6.v20151106'
-  compile 'org.eclipse.jetty:jetty-security:9.3.6.v20151106'
-  compile 'org.eclipse.jetty:jetty-server:9.3.6.v20151106'
-  compile 'org.eclipse.jetty:jetty-servlet:9.3.6.v20151106'
-  compile 'org.eclipse.jetty:jetty-util:9.3.6.v20151106'
-  compile 'org.eclipse.jetty:jetty-webapp:9.3.6.v20151106'
-  compile 'org.eclipse.jetty:jetty-xml:9.3.6.v20151106'
-  compile core_ext_dependencies
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-http:9.3.6.v20151106'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-io:9.3.6.v20151106'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-security:9.3.6.v20151106'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-server:9.3.6.v20151106'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-servlet:9.3.6.v20151106'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-util:9.3.6.v20151106'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-webapp:9.3.6.v20151106'
+  addProjectExtDependency 'compile', 'org.eclipse.jetty:jetty-xml:9.3.6.v20151106'
+  addTargetDirCoreExtJarDependencies 'compile'
+  
+  // TODO runtime dependsOn ":console:servlets"  ???  
+
+  // N.B. root project adds test common dependencies
 }

--- a/console/servlets/build.gradle
+++ b/console/servlets/build.gradle
@@ -16,14 +16,15 @@ distsDirName = 'webapps'
 plugins.apply 'war'
 
 dependencies {
-  providedCompile 'javax.servlet:javax.servlet-api:3.1.0'
-  providedCompile project(':utils:streamscope')
-  providedCompile core_ext_dependencies
+  addTargetDirProjectJarDependency 'providedCompile', ':utils:streamscope'
+  addProjectExtDependency 'providedCompile', 'javax.servlet:javax.servlet-api:3.1.0'
+  addTargetDirCoreExtJarDependencies 'providedCompile'
+
+  // N.B. root project adds test common dependencies
 }
 
 war {
-  configure jarOptions
-  destinationDir = project.distsDir
+  destinationDir = file("$target_java8_dir/$project.simpleGroupName/webapps")
   archiveName 'console.war'
   from file('webapp_content/html')
   into('resources') {
@@ -33,6 +34,10 @@ war {
     from file('webapp_content/js')
   }
   webXml = file('webapp_content/WEB-INF/console.xml')
+  
+  doFirst {
+    configure jarOptions
+  }
 }
 
 testClasses.dependsOn war

--- a/edgent_overview.html
+++ b/edgent_overview.html
@@ -225,9 +225,14 @@ an Eclipse Jetty based implementation:
 <li>{@code <edgent-target>/connectors/javax.websocket-client/lib/javax.websocket-client.jar}</li>
 </ul>
 <p>
+Include jars for any Edgent analytic features you use:
+<ul>
+<li>{@code <edgent-target>/analytics/math3/lib/edgent.analytics.math3.jar}</li>
+<li>{@code <edgent-target>/analytics/sensors/lib/edgent.analytics.sensors.jar}</li>
+</ul>
 Include jars for any Edgent utility features you use:
 <ul>
-<li>{@code <edgent-target>/utils/metrics/lib/edgent.utils.metrics.jar} - for the {@code edgent.metrics} package</li>
+<li>{@code <edgent-target>/utils/metrics/lib/edgent.utils.metrics.jar} - for the {@code org.apache.edgent.metrics} package</li>
 </ul>
 Edgent uses <a href="www.slf4j.org">slf4j</a> for logging,
 leaving the decision of the actual logging implementation to your application

--- a/providers/development/build.gradle
+++ b/providers/development/build.gradle
@@ -12,11 +12,13 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:direct')
-  compile project(':console:server')
-  compile project(':utils:metrics')
-  compile project(':utils:streamscope')
-  compile project(':runtime:jmxcontrol')
+  addTargetDirProjectJarDependency 'compile', ':providers:direct'
+  addTargetDirProjectJarDependency 'compile', ':console:server'
+  addTargetDirProjectJarDependency 'compile', ':utils:metrics'
+  addTargetDirProjectJarDependency 'compile', ':utils:streamscope'
+  addTargetDirProjectJarDependency 'compile', ':runtime:jmxcontrol'
+
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':utils:streamscope'

--- a/providers/direct/build.gradle
+++ b/providers/direct/build.gradle
@@ -12,15 +12,16 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile project(':spi:topology')
-  compile project(':spi:graph')
-  compile project(':runtime:appservice')
-  compile project(':runtime:etiao')
-  compile project(':runtime:jsoncontrol')
-  compile core_ext_dependencies
-  testCompile project(':utils:metrics')
-  testCompile project(':runtime:appservice')
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirProjectJarDependency 'compile', ':spi:topology'
+  addTargetDirProjectJarDependency 'compile', ':spi:graph'
+  addTargetDirProjectJarDependency 'compile', ':runtime:appservice'
+  addTargetDirProjectJarDependency 'compile', ':runtime:etiao'
+  addTargetDirProjectJarDependency 'compile', ':runtime:jsoncontrol'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  addTargetDirProjectJarDependency 'testCompile', ':utils:metrics'
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology', ':utils:metrics', ':runtime:appservice'

--- a/providers/iot/build.gradle
+++ b/providers/iot/build.gradle
@@ -12,13 +12,15 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:direct')
-  compile project(':runtime:jsoncontrol')
-  compile project(':runtime:appservice')
-  compile project(':connectors:iot')
-  compile project(':connectors:pubsub')
-  compile project(':apps:iot')
-  compile project(':apps:runtime')
+  addTargetDirProjectJarDependency 'compile', ':providers:direct'
+  addTargetDirProjectJarDependency 'compile', ':runtime:jsoncontrol'
+  addTargetDirProjectJarDependency 'compile', ':runtime:appservice'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iot'
+  addTargetDirProjectJarDependency 'compile', ':connectors:pubsub'
+  addTargetDirProjectJarDependency 'compile', ':apps:iot'
+  addTargetDirProjectJarDependency 'compile', ':apps:runtime'
+
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology'

--- a/runtime/appservice/build.gradle
+++ b/runtime/appservice/build.gradle
@@ -12,7 +12,9 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:execution')
-  compile project(':api:topology')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/runtime/etiao/build.gradle
+++ b/runtime/etiao/build.gradle
@@ -12,10 +12,12 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:execution')
-  compile project(':api:graph')
-  compile project(':spi:graph')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:graph'
+  addTargetDirProjectJarDependency 'compile', ':spi:graph'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:graph'

--- a/runtime/jmxcontrol/build.gradle
+++ b/runtime/jmxcontrol/build.gradle
@@ -12,7 +12,9 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:execution')
-  compile project(':api:function')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:function'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/runtime/jobregistry/build.gradle
+++ b/runtime/jobregistry/build.gradle
@@ -12,7 +12,9 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:execution')
-  compile project(':api:topology')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/runtime/jsoncontrol/build.gradle
+++ b/runtime/jsoncontrol/build.gradle
@@ -12,7 +12,9 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:execution')
-  compile project(':api:function')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:function'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/samples/apps/build.gradle
+++ b/samples/apps/build.gradle
@@ -12,15 +12,14 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:development')
-  compile project(':providers:direct')
-  compile project(':connectors:mqtt')
-  compile project(':connectors:file')
-  compile project(':connectors:serial')
-  compile project(':analytics:math3')
-  compile project(':analytics:sensors')
-  compile project(':samples:utils')
-  compile core_ext_dependencies
-  
-  runtime samples_ext_dependencies
+  // N.B. common dependencies are set in root build.gradle
+
+  addTargetDirProjectJarDependency 'compile', ':connectors:mqtt'
+  addTargetDirProjectJarDependency 'compile', ':connectors:file'
+  addTargetDirProjectJarDependency 'compile', ':connectors:serial'
+  addTargetDirProjectJarDependency 'compile', ':analytics:math3'
+  addTargetDirProjectJarDependency 'compile', ':analytics:sensors'
+  addTargetDirProjectJarDependency 'compile', ':samples:utils'
+
+  // N.B. root project adds test common dependencies
 }

--- a/samples/connectors/build.gradle
+++ b/samples/connectors/build.gradle
@@ -12,17 +12,17 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:development')
-  compile project(':providers:direct')
-  compile project(':connectors:mqtt')
-  compile project(':connectors:kafka')
-  compile project(':connectors:file')
-  compile project(':connectors:iotp')
-  compile project(':connectors:jdbc')
-  compile project(':connectors:serial')
-  compile project(':samples:topology')
-  compile project(':samples:utils')
-  compile core_ext_dependencies
-  
-  runtime samples_ext_dependencies
+  // N.B. common dependencies are set in root build.gradle
+
+  addTargetDirProjectJarDependency 'compile', ':analytics:math3'
+  addTargetDirProjectJarDependency 'compile', ':connectors:mqtt'
+  addTargetDirProjectJarDependency 'compile', ':connectors:kafka'
+  addTargetDirProjectJarDependency 'compile', ':connectors:file'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iotp'
+  addTargetDirProjectJarDependency 'compile', ':connectors:jdbc'
+  addTargetDirProjectJarDependency 'compile', ':connectors:serial'
+  addTargetDirProjectJarDependency 'compile', ':samples:topology'
+  addTargetDirProjectJarDependency 'compile', ':samples:utils'
+
+  // N.B. root project adds test common dependencies
 }

--- a/samples/console/build.gradle
+++ b/samples/console/build.gradle
@@ -12,10 +12,9 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:development')
-  compile project(':providers:direct')
-  compile project(':console:server')
-  compile core_ext_dependencies
-  
-  runtime samples_ext_dependencies
+  // N.B. common dependencies are set in root build.gradle
+
+  addTargetDirProjectJarDependency 'compile', ':console:server'
+
+  // N.B. root project adds test common dependencies
 }

--- a/samples/scenarios/build.gradle
+++ b/samples/scenarios/build.gradle
@@ -12,13 +12,14 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:development')
-  compile project(':providers:direct')
-  compile project(':samples:connectors')
-  compile project(':providers:iot')
-  compile project(':connectors:iotp')
-  compile 'com.pi4j:pi4j-core:1.0'
-  compile core_ext_dependencies
-  
-  runtime samples_ext_dependencies
+  // N.B. common dependencies are set in root build.gradle
+
+  addTargetDirProjectJarDependency 'compile', ':analytics:math3'
+  addTargetDirProjectJarDependency 'compile', ':samples:connectors'
+  addTargetDirProjectJarDependency 'compile', ':providers:iot'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iot'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iotp'
+  addProjectExtDependency 'compile', 'com.pi4j:pi4j-core:1.0'
+
+  // N.B. root project adds test common dependencies
 }

--- a/samples/topology/build.gradle
+++ b/samples/topology/build.gradle
@@ -11,13 +11,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 dependencies {
-  compile project(':providers:development')
-  compile project(':providers:direct')
-  compile project(':analytics:math3')
-  compile project(':runtime:jobregistry')
-  compile project(':samples:utils')
-  compile core_ext_dependencies
-  
-  runtime samples_ext_dependencies
+  // N.B. common dependencies are set in root build.gradle
+
+  addTargetDirProjectJarDependency 'compile', ':analytics:math3'
+  addTargetDirProjectJarDependency 'compile', ':runtime:jobregistry'
+  addTargetDirProjectJarDependency 'compile', ':samples:utils'
+
+  // N.B. root project adds test common dependencies
 }

--- a/samples/utils/build.gradle
+++ b/samples/utils/build.gradle
@@ -12,12 +12,11 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:development')
-  compile project(':providers:direct')
-  compile project(':utils:metrics')
-  compile project(':analytics:math3')
-  compile project(':analytics:sensors')
-  compile core_ext_dependencies
-  
-  runtime samples_ext_dependencies
+  // N.B. common dependencies are set in root build.gradle
+
+  addTargetDirProjectJarDependency 'compile', ':utils:metrics'
+  addTargetDirProjectJarDependency 'compile', ':analytics:math3'
+  addTargetDirProjectJarDependency 'compile', ':analytics:sensors'
+
+  // N.B. root project adds test common dependencies
 }

--- a/scripts/connectors/mqtt/mqtt.properties
+++ b/scripts/connectors/mqtt/mqtt.properties
@@ -1,4 +1,5 @@
 mqtt.serverURLs=tcp://localhost:1883
+#mqtt.serverURLs=tcp://test.mosquitto.org:1883
 mqtt.topic=mqttSampleTopic
 #mqtt.userName=
 #mqtt.password=

--- a/settings.gradle
+++ b/settings.gradle
@@ -70,5 +70,8 @@ if (System.env.ANDROID_SDK_PLATFORM != null) {
   include 'android:topology'
   include 'android:hardware'
 }
+else {
+  logger.lifecycle 'ANDROID_SDK_PLATFORM ev not set. Omitting android:{topology,hardware} projects.'
+}
 
 rootProject.name = build_name

--- a/spi/graph/build.gradle
+++ b/spi/graph/build.gradle
@@ -12,7 +12,9 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:execution')
-  compile project(':api:graph')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:execution'
+  addTargetDirProjectJarDependency 'compile', ':api:graph'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/spi/topology/build.gradle
+++ b/spi/topology/build.gradle
@@ -12,6 +12,8 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }

--- a/test/fvtiot/build.gradle
+++ b/test/fvtiot/build.gradle
@@ -12,10 +12,12 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':providers:iot')
-  compile project(':runtime:appservice')
-  compile project(':runtime:jsoncontrol')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':providers:iot'
+  addTargetDirProjectJarDependency 'compile', ':runtime:appservice'
+  addTargetDirProjectJarDependency 'compile', ':runtime:jsoncontrol'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':apps:iot'

--- a/test/svt/build.gradle
+++ b/test/svt/build.gradle
@@ -11,16 +11,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-def projectGroup = "$project.group".replace("edgent.", "")
-def lib= "${rootProject.ext.target_java8_dir}/" + projectGroup + "/$project.name".replaceAll(":", "/")
+def lib= "$target_java8_dir/$project.simpleGroupName/$project.name"
 
 //def lib="${project.distsDir}/lib"
 
 dependencies {
-  compile project(':providers:development')
-  compile project(':samples:apps')
-  compile project(':connectors:iotp')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':providers:development'
+  addTargetDirProjectJarDependency 'compile', ':samples:apps'
+  addTargetDirProjectJarDependency 'compile', ':connectors:iotp'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }
 
 tasks.build.doFirst(){

--- a/utils/metrics/build.gradle
+++ b/utils/metrics/build.gradle
@@ -12,8 +12,10 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology'

--- a/utils/streamscope/build.gradle
+++ b/utils/streamscope/build.gradle
@@ -12,8 +12,10 @@
  * limitations under the License.
  */
 dependencies {
-  compile project(':api:topology')
-  compile core_ext_dependencies
+  addTargetDirProjectJarDependency 'compile', ':api:topology'
+  addTargetDirCoreExtJarDependencies 'compile'
+
+  // N.B. root project adds test common dependencies
 }
 
 addCompileTestDependencies ':api:topology'


### PR DESCRIPTION
The upshot is to do like the ant-based scripts and specify
inter-project, core-ext, and project-private-ext
dependencies against jars in the target dir.
The original conversion specified on inter-project dependencies on
"projects" (hence their artifacts not in the target-dir) and that caused
a host of issues.

With the changes things like manifest-classpath generation are
simplified and overall the gradle build now adhears to the policies:
- Edgent projects depend on other project's jars in the target-dir, not
their classes
- Edgent project jars have a manifest-classpath that handles the
project's "private" inter-project dependencies as well as the project's
"private" external component dependencies.
- We build a target dir that includes the project's jar as well as the
project's external dependency jars
- The tests compile and run against the project jars in the target dir
(as external/integration test code would).
- The samples compile and run against the project jars in the target dir
(as user code would).

All seems fine including when building and testing with
ANDROID_SDK_PLATFORM and DERBY_HOME set:
- all tests pass (sans manual run of kafka tests)
- sample scripts seem to run appropriately
- console comes up

TODOs
- edgent.android.{topology,hardware}.jar manifest classpath and the
"android.jar" - compared to ant-build?


More details of the changes...

- define addTargetDirProjectJarDependency(),
addTargetDirExtJarDependency(), addTargetDirCoreExtDependency(),
addTargetDirCoreExtDependencies(), addProjectExtDependency()
- change all build.gradle to use them
- configure common sample dependencies in root build.gradle
- adapt manifest classpath generation in light of above
- rework how common_ext_dependencies files get added to target-dir/ext

Other cleanup,etc
- generate project jar/war directly into targetdir with the correct name
(remove "copy/rename" of jar created by default far task)
- fix ant -> gradle conversion of api/function project
- add previously (benign) absent api/function dependency from
api/topology
- remove updateTargetDir task -- just add processing as "doLast" to the
assemble task
- other root build.gradle refactoring for hygiene
- fix issues caused by kafka's transitive dependencies
- update connectors:iotp to watson-iot:0.1.5 - initial motivation was to
cleanup the fact that 0.1.1 had dependency on a mqttv3 SNAPSHOT version
- fix aggregateJavadoc processing warnings
- fix test runtime classpath so it uses the project's target-dir jar