### PR TITLE
EDGENT-262 console license changes

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -199,3 +199,6 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+   ======================================
+   This product contains content covered by MIT and "BSD 3 Clause" licenses. See console/servlets/LICENSE.

--- a/console/servlets/LICENSE
+++ b/console/servlets/LICENSE
@@ -1,0 +1,31 @@
+This product contains content covered by MIT/BSD-3-Clause licenses.
+The files under servlets/webapp_content/ext are:
+
+d3.legend.js: 
+Obtained from: https://github.com/jieter/d3-legend/blob/master/d3.legend.js
+License type: MIT license
+License: console/servlets/webapp_content/exit/MIT.LICENSE
+
+
+d3.min.js: 
+Obtained from: https://github.com/d3/d3/releases/tag/v3.5.9
+License type: BSD license
+License: https://github.com/d3/d3/blob/master/LICENSE
+
+sankey_edgent.js : 
+Originally obtained sankey.js from: https://github.com/d3/d3-sankey
+Modified it and renamed it to sankey_edgent.js
+License type: BSD license
+License: https://github.com/d3/d3-sankey/blob/master/LICENSE
+
+jquery-ui.min.js (located in jquery-ui-1.11.4.custom):
+Obtained from:  http://jqueryui.com (select 'Custom Download')
+License type: MIT license
+License: https://github.com/jquery/jquery-ui/blob/master/LICENSE.txt
+All of the css files were objtained from the same url: http://jqueryui.com
+
+jquery.js (located in jquery-ui-1.11.4.custom/external/jquery/):
+Obtained from: https://code.jquery.com/jquery/
+License type:MIT
+License: https://github.com/jquery/jquery/blob/master/LICENSE.txt
+

--- a/console/servlets/webapp_content/js/ext/MIT.LICENSE
+++ b/console/servlets/webapp_content/js/ext/MIT.LICENSE
@@ -1,0 +1,20 @@
+MIT License
+Copyright (c) 2012 ziggy.jonsson.nyc@gmail.com
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/console/servlets/webapp_content/js/ext/jquery-ui-1.11.4.custom/jquery-ui.LICENSE
+++ b/console/servlets/webapp_content/js/ext/jquery-ui-1.11.4.custom/jquery-ui.LICENSE
@@ -1,0 +1,43 @@
+Copyright jQuery Foundation and other contributors, https://jquery.org/
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/jquery/jquery-ui
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+====
+
+Copyright and related rights for sample code are waived via CC0. Sample
+code is defined as all source code contained within the demos directory.
+
+CC0: http://creativecommons.org/publicdomain/zero/1.0/
+
+====
+
+All files located in the node_modules and external directories are
+externally maintained libraries used by this software which have their
+own licenses; we recommend you read them, as their terms may differ from
+the terms above.


### PR DESCRIPTION
I added a console/servlets/LICENSE file containing the following:

This initial line of text:
"This product contains content covered by MIT/BSD-3-Clause licenses."
then where the ext files came from, and their associated license type, a URL to the license or path in the repository to the license, and added a couple of license.
I also updated <repo>/LICENSE to mention the console/servlets/LICENSE file