### PR TITLE
Edgent-281 Misc build changes for "release"

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -87,7 +87,7 @@ unique tasks:
 * `reports` : Generate JUnit and Code Coverage reports in `build\distributions\reports`. Use after executing the `test` target. 
   * `reports\tests\overview-summary.html` - JUnit test report
   * `reports\coverage\index.html` - Code coverage report
-* `release` : Build release bundles in `build/release-edgent`, that includes subsets of the Edgent jars that run on Java 7 (`build/distributions/java7`) and Android (`build/distributions/android`).
+* `release` : Build release bundles in `build/release-edgent`, that includes subsets of the Edgent jars that run on Java 7 (`build/distributions/java7`) and Android (`build/distributions/android`). By default SNAPSHOT bundles are created.  Specify `-Dedgent.snapshotId=""` to create bundles for a formal release.
 * `signAll` : Sign the release bundles in `build/release-edgent` (first run `release`).  You will be promoted for your PGP code signing key's Id, the location of the keyring file, and the secret key password.  Default response values may be set with environment variables:
   * `GPG_ID` - the code signing key's id (e.g., D0F56CAD)
   * `GPG_SECRING` - path to the secret key's keyring file

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,11 @@ ext {
   now = new Date()
   DSTAMP = String.format('%tY%<tm%<td', now)
   TSTAMP = String.format('%tH%<tM', now)
+  
+  snapshotId = "-SNAPSHOT-${DSTAMP}-${TSTAMP}"
+  if (System.properties['edgent.snapshotId'] != null) {
+    snapshotId = System.properties['edgent.snapshotId']
+  }
                    
   external_jars_dir = "$rootProject.projectDir/externalJars/java8"
   
@@ -687,11 +692,11 @@ task addVersionDotTxt {
 
 task releaseTarGz(type: Tar) {
   description = 'Create binary release tgz in target_dir'
-  archiveName = "${build_name}-${build_version}-${DSTAMP}-${TSTAMP}-bin.tgz"
+  archiveName = "apache-${build_name}-${build_version}${snapshotId}-bin.tgz"
   compression = Compression.GZIP
   destinationDir = new File("${target_dir}/../release-edgent")
   duplicatesStrategy 'exclude'
-  into "${build_name}"
+  into "${build_name}-${build_version}${snapshotId}"
   // make some things first in the tgz
   with copySpec {
     rename { 'LICENSE' }
@@ -723,11 +728,11 @@ task releaseTarGz(type: Tar) {
 
 task srcReleaseTarGz(type: Tar) {
   description = 'Create source release tgz in target_dir'
-  archiveName = "${build_name}-${build_version}-${DSTAMP}-${TSTAMP}-src.tgz"
+  archiveName = "apache-${build_name}-${build_version}${snapshotId}-src.tgz"
   compression = Compression.GZIP
   destinationDir = new File("${target_dir}/../release-edgent")
   duplicatesStrategy 'exclude'
-  into "${build_name}"
+  into "${build_name}-${build_version}${snapshotId}-src"
   // make some things first in the tgz
   from 'LICENSE', 'NOTICE'
   from 'DISCLAIMER', 'JAVA_SUPPORT.md'

--- a/edgent_overview.html
+++ b/edgent_overview.html
@@ -25,7 +25,7 @@ analytics at the <i>edge</i>.
 Apache Edgent is an effort undergoing incubation at The Apache Software Foundation (ASF), sponsored by Apache Incubator PMC. Incubation is required of all newly accepted projects until a further review indicates that the infrastructure, communications, and decision making process have stabilized in a manner consistent with other successful ASF projects. While incubation status is not necessarily a reflection of the completeness or stability of the code, it does indicate that the project has yet to be fully endorsed by the ASF.
 </em>
 </P>
-<H1>Edgent v0.4</H1>
+<H1>Edgent</H1>
 <OL>
 <LI><a href="#overview">Overview</A></LI>
 <LI><a href="#model">Programming Model</A></LI>

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,5 +16,5 @@
 # under the License.
 build_group: org.apache.edgent
 build_name: edgent
-build_version: 0.4.1
+build_version: 1.0.0
 build_vendor: Apache Software Foundation

--- a/legal/source-release-readme
+++ b/legal/source-release-readme
@@ -21,5 +21,5 @@ See Getting Started https://edgent.apache.org/docs/edgent-getting-started
 
 For more information about the Edgent sources, testing, and
 contributing to Edgent runtime development see DEVELOPMENT.md in the source tree
-or in the github repository http://www.apache.org/dist/incubator/edgent
-
+or in the ASF git repository https://git-wip-us.apache.org/repos/asf/incubator-edgent.git
+or in the repository mirror at github https://github.com/apache/incubator-edgent.


### PR DESCRIPTION
add "apache" to tgz names
add SNAPSHOT and <DATE>-<TIME> to build tgz name when appropriate
make src tgz extract to different dir than binary tgz
update current snapshot build version id
fix URL in source release README
remove version Id in edgent_overview.html (additional maintenance and
it's already present on the javadoc page that the overview is
incorporated into).