### PR TITLE
Edgent-304 Always build edgent.android.{hardware,topology}.jar

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,11 +34,6 @@ these additional development software tools.
 
 * Java 8 - The development setup assumes Java 8 and Linux. 
 
-These are optional
-
-* Android SDK - Allows building of Android specific modules. Set the environment variable `ANDROID_SDK_PLATFORM` to
-the location of the Android platform so that ${ANDROID_SDK_PLATFORM}/android.jar points to a valid jar.
-
 ### Building a Binary Release Bundle
 
 Building an Edgent binary release bundle:

--- a/android/hardware/build.gradle
+++ b/android/hardware/build.gradle
@@ -12,12 +12,11 @@
  * limitations under the License.
  */
 
-// NB settings.gradle conditionally includes this project
-// based on System.env.ANDROID_SDK_PLATFORM
+ext.androidJarSpec = 'com.google.android:android:4.1.1.4@jar'
 
 dependencies {
   addTargetDirProjectJarDependency 'compile', ':api:topology'
-  compile files("${System.env.ANDROID_SDK_PLATFORM}/android.jar")
+  addProjectExtDependency 'compile', androidJarSpec
   
   // N.B. root project adds test common dependencies
 }

--- a/android/hardware/build.xml
+++ b/android/hardware/build.xml
@@ -27,6 +27,13 @@
   <property name="component.path" value="android/hardware"/>
   <import file="../../common-build.xml"/>
 
+  <property name="android.sdk.platform.jar" value=""/>
+<!--	
+  <condition property="android.sdk.platform.jar" value="env.ANDROID_SDK_PLATFORM_JAR">
+    <isset property="env.ANDROID_SDK_PLATFORM_JAR" />
+  </condition>
+-->
+
   <path id="compile.classpath">
     <pathelement location="${edgent.lib}/edgent.api.topology.jar" />
   </path>
@@ -34,7 +41,7 @@
 
   <path id="android.classpath">
     <path refid="compile.classpath"/>
-    <pathelement location="${env.ANDROID_SDK_PLATFORM}/android.jar"/>
+    <pathelement location="${android.sdk.platform.jar}"/>
   </path>
 
   <path id="test.compile.classpath">
@@ -48,7 +55,7 @@
     <path refid="test.common.classpath" />
   </path>
 
- <target name="all" if="env.ANDROID_SDK_PLATFORM">
+ <target name="all" if="android.sdk.platform.jar">
     <antcall target="edgent.common.all"/>
  </target>
 

--- a/android/topology/build.gradle
+++ b/android/topology/build.gradle
@@ -12,13 +12,10 @@
  * limitations under the License.
  */
 
-// NB settings.gradle conditionally includes this project
-// based on System.env.ANDROID_SDK_PLATFORM
-
 dependencies {
   addTargetDirProjectJarDependency 'compile', ':api:topology'
   addTargetDirProjectJarDependency 'compile', ':api:oplet'
-  compile files("${System.env.ANDROID_SDK_PLATFORM}/android.jar")
+  addProjectExtDependency 'compile', project(':android:hardware').androidJarSpec
 
   // N.B. root project adds test common dependencies
 }

--- a/android/topology/build.xml
+++ b/android/topology/build.xml
@@ -27,6 +27,13 @@
   <property name="component.path" value="android/topology"/>
   <import file="../../common-build.xml"/>
 
+  <property name="android.sdk.platform.jar" value=""/>
+<!--	
+  <condition property="android.sdk.platform.jar" value="env.ANDROID_SDK_PLATFORM_JAR">
+    <isset property="env.ANDROID_SDK_PLATFORM_JAR" />
+  </condition>
+-->
+
   <path id="compile.classpath">
     <pathelement location="${edgent.lib}/edgent.api.topology.jar" />
     <pathelement location="${edgent.lib}/edgent.api.oplet.jar" />
@@ -35,7 +42,7 @@
 
   <path id="android.classpath">
     <path refid="compile.classpath"/>
-    <pathelement location="${env.ANDROID_SDK_PLATFORM}/android.jar"/>
+    <pathelement location="${android.sdk.platform.jar}"/>
   </path>
 
   <path id="test.compile.classpath">
@@ -49,7 +56,7 @@
     <path refid="test.common.classpath" />
   </path>
 
- <target name="all" if="env.ANDROID_SDK_PLATFORM">
+ <target name="all" if="android.sdk.platform.jar">
     <antcall target="edgent.common.all"/>
  </target>
 

--- a/build.gradle
+++ b/build.gradle
@@ -131,7 +131,9 @@ task copyCommonExtJars << {
 
 def String mkJarNameFromSpec(String jarSpec) {
   // e.g. 'com.google.code.gson:gson:2.2.4' => gson-2.2.4.jar
-  return jarSpec.split(':')[1] + '-' + jarSpec.split(':')[2] + '.jar'
+  // e.g. 'com.google.code.gson:gson:2.2.4@jar' => gson-2.2.4.jar
+  def sfx = jarSpec.endsWith('@jar') ? "" : '.jar'
+  return jarSpec.split(':')[1] + '-' + jarSpec.split(':')[2].replace('@','.') + sfx
 }
 
 def getProjectExtDepFiles(Project proj) { // project's direct ext deps and their transitive deps

--- a/platform/java7/build.gradle
+++ b/platform/java7/build.gradle
@@ -54,6 +54,12 @@ task preAntTask << {
   // make retrolambda available to the ant tooling
   copyProjectExtJarsFn2 "$external_jars_dir/tools"
   ant.properties['retrolambda.jar'] = "$external_jars_dir/tools/$retrolambdaJarName"
+  
+  // make android.jar available to the ant tooling
+  def hwProj = project(':android:hardware')
+  hwProj.copyProjectExtJarsFn "$external_jars_dir"
+  ant.properties['android.sdk.platform.jar'] = 
+    "$external_jars_dir/${hwProj.targetRelProjExtDir}/" + mkJarNameFromSpec(hwProj.androidJarSpec)
 }
 
 ant_retro7.doFirst { 

--- a/platform/java7/build.xml
+++ b/platform/java7/build.xml
@@ -42,6 +42,13 @@
     <property name="metrics.ext.dir" value="metrics-${metrics.version}/"/>
     <property name="retrolambda.jar" location="ext/retrolambda-${retrolambda.version}.jar"/>
 
+    <property name="android.sdk.platform.jar" value=""/>
+<!--	
+    <condition property="android.sdk.platform.jar" value="env.ANDROID_SDK_PLATFORM_JAR">
+      <isset property="env.ANDROID_SDK_PLATFORM_JAR" />
+    </condition>
+-->
+
 	<path id="edgent.classpath">
         <pathelement location="${ext.dir}/${slf4j.ext.dir}slf4j-api-${slf4j.version}.jar"/>
         <pathelement location="${ext.dir}/${gson.ext.dir}gson-${gson.version}.jar"/>
@@ -175,7 +182,7 @@
 		</copy>
 
 	</target>
-	<target name="retro7.edgent.android" if="env.ANDROID_SDK_PLATFORM">
+	<target name="retro7.edgent.android" if="android.sdk.platform.jar">
 		<retro7 qjar="edgent.android.topology.jar" qdir="android/topology/lib" />
 		<retro7 qjar="edgent.android.hardware.jar" qdir="android/hardware/lib" />
 	</target>

--- a/settings.gradle
+++ b/settings.gradle
@@ -66,12 +66,7 @@ include 'test:fvtiot'
 include 'test:svt'
 include 'platform:java7'
 include 'platform:android'
-if (System.env.ANDROID_SDK_PLATFORM != null) {
-  include 'android:topology'
-  include 'android:hardware'
-}
-else {
-  logger.lifecycle 'ANDROID_SDK_PLATFORM ev not set. Omitting android:{topology,hardware} projects.'
-}
+include 'android:topology'
+include 'android:hardware'
 
 rootProject.name = build_name


### PR DESCRIPTION
Get android.jar from maven for compilation

Note: the android jar is not included in the binary tgz.
ANDROID_SDK_PLATFORM is no longer used / has no effect.