### PR TITLE
Fix publish by ignoring platform projects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -210,8 +210,10 @@ subprojects {
   if (aggregatorOnlyProjects.contains(project.path)) {
     return
   }
-
-  apply plugin: 'maven-publish'
+  
+  if(!project.group.equals("edgent.platform")){
+  	apply plugin: 'maven-publish'
+  }
   apply plugin: 'java'
   apply plugin: "jacoco"
  
@@ -621,6 +623,7 @@ subprojects {
 
   // support for 'gradle publishToMavenLocal' etc 
   // TODO publishing test.{fvt,svt} and samples ... doesn't seem desirable? e.g., we're excluding test.{fvt,svt} jars from the tgz
+  if(!project.group.equals("edgent.platform")){
   publishing {
     publications {
       mavenJava(MavenPublication) {
@@ -636,6 +639,7 @@ subprojects {
         }
       }
     }
+  }
   }  
 }
 


### PR DESCRIPTION
This commit fixed the following issue:

In the current version, if you run gradle publishToMavenLocal or gradle publish, it will throw the following error:

Execution failed for task ':platform:android:publishMavenJavaPublicationToMavenLocal'.
> Failed to publish publication 'mavenJava' to repository 'mavenLocal'
   > Invalid publication 'mavenJava': artifact file does not exist: '/git/quarks/incubator-edgent/build/distributions/java8/platform/android/lib/edgent.platform.android.jar'

The edgent.platform.java project also has the similar problem that prevent the project from publishing to Maven.
