### PR TITLE
add Sizzle license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -223,4 +223,7 @@ For details, see licenses/jquery-ui.MIT
 This product bundles portions of jquery which is available under a MIT license.
 For details, see licenses/jquery.MIT
 
+The bundled jquery bundles Sizzle which is available under a MIT license.
+For details, see licenses/sizzle.MIT
+
 ======================================

--- a/LICENSE
+++ b/LICENSE
@@ -220,7 +220,7 @@ For details, see licenses/d3-sankey.BSD
 This product bundles portions of jquery-ui which is available under a MIT license.
 For details, see licenses/jquery-ui.MIT
  
-This product bundles portions of jquery which is available under a MIT license.
+The bundled jquery-ui bundles jquery which is available under a MIT license.
 For details, see licenses/jquery.MIT
 
 The bundled jquery bundles Sizzle which is available under a MIT license.

--- a/binary-release/LICENSE
+++ b/binary-release/LICENSE
@@ -395,4 +395,7 @@ console/webapps
         The file bundles portions of jquery which is available under a MIT license.
         For details, see licenses/jquery.MIT
     
+        The bundled jquery bundles Sizzle which is available under a MIT license.
+        For details, see licenses/sizzle.MIT
+    
 --------------------------------

--- a/binary-release/LICENSE
+++ b/binary-release/LICENSE
@@ -392,7 +392,7 @@ console/webapps
         The file bundles portions of jquery-ui which is available under a MIT license.
         For details, see licenses/jquery-ui.MIT
  
-        The file bundles portions of jquery which is available under a MIT license.
+        The bundled jquery-ui bundles jquery which is available under a MIT license.
         For details, see licenses/jquery.MIT
     
         The bundled jquery bundles Sizzle which is available under a MIT license.

--- a/licenses/sizzle.MIT
+++ b/licenses/sizzle.MIT
@@ -1,4 +1,5 @@
 servlets/webapp_content/js/ext/jquery-ui-1.11.4.custom/external/jquery/jquery.js:
+For included Sizzle.js
 License type: MIT
 
 Copyright 2013 jQuery Foundation and other contributors


### PR DESCRIPTION
bundled jquery-ui bundles jquery which bundles sizzle (see our bundled
jquery.js)

update jquery.MIT license with license text from jquery-1.10.2 in github
(version noted in jquery.js)
add licenses/sizzle.MIT for sizzle version bundled by jquery-1.10.2
(jquery-1.10.2 github links to sizzle 1.10.2 github version)