### PR TITLE
[Edgent-366] Tolerate trailing spaces in serverURLs MqttConfig properties file

### DIFF
--- a/connectors/mqtt/src/main/java/org/apache/edgent/connectors/mqtt/MqttConfig.java
+++ b/connectors/mqtt/src/main/java/org/apache/edgent/connectors/mqtt/MqttConfig.java
@@ -124,7 +124,7 @@ public class MqttConfig {
         setConfig(p, "mqtt.persistence", 
                 val -> config.setPersistence(newPersistenceProvider(val)));
         setConfig(p, "mqtt.serverURLs", 
-                val -> config.setServerURLs(val.split(",")));
+                val -> config.setServerURLs(val.trim().split(",")));
         setConfig(p, "mqtt.subscriberIdleReconnectIntervalSec", 
                 val -> config.setSubscriberIdleReconnectInterval(Integer.valueOf(val)));
         setConfig(p, "mqtt.trustStore", 


### PR DESCRIPTION
Had a space at the end of the property and it was unclear why the URL
failed validation.