### PR TITLE
[Edgent-380] update MQTT connector to use paho-mqtt 1.1.0

### DIFF
--- a/scripts/connectors/iotp/runiotpsensors.sh
+++ b/scripts/connectors/iotp/runiotpsensors.sh
@@ -30,7 +30,7 @@ edgent=../../..
 # IBM Watson IoT Platform and a sample is in this directory
 # (omitting values for the authorization tokens).
 
-#export CLASSPATH=${edgent}/samples/lib/edgent.samples.connectors.jar
+export CLASSPATH=${edgent}/samples/lib/edgent.samples.connectors.jar
 
 # https://github.com/ibm-watson-iot/iot-java/tree/master#migration-from-release-015-to-021
 # Uncomment the following to use the pre-0.2.1 WIoTP client behavior.

--- a/scripts/connectors/iotp/runiotpsensors.sh
+++ b/scripts/connectors/iotp/runiotpsensors.sh
@@ -30,14 +30,7 @@ edgent=../../..
 # IBM Watson IoT Platform and a sample is in this directory
 # (omitting values for the authorization tokens).
 
-# Avoid a paho mqtt class security exception.
-# The connector samples jar has dependencies on both the iotp and mqtt connectors
-# and those have dependencies on different versions of the paho mqtt jar.
-# Ensure the right one is used for this sample.
-#
 #export CLASSPATH=${edgent}/samples/lib/edgent.samples.connectors.jar
-IOTP_MQTT_JAR=`ls ${edgent}/connectors/iotp/ext/org.eclipse.paho.client.mqtt*.jar`
-export CLASSPATH=${IOTP_MQTT_JAR}:${edgent}/samples/lib/edgent.samples.connectors.jar
 
 # https://github.com/ibm-watson-iot/iot-java/tree/master#migration-from-release-015-to-021
 # Uncomment the following to use the pre-0.2.1 WIoTP client behavior.


### PR DESCRIPTION
- remove the sample run script workaround that was added earlier