### PR TITLE
[EDGENT-413] Adding publishing support for ASF repos.

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -245,6 +245,20 @@ $ ./gradlew test7Reports  # generate the JUnit and coverage reports
 
 ## Publish to Maven Repository
 
+### Pushing Snapshots
+
+Snapshots may be published to the ASF's internal Nexus instance for developer testing.  To publish these, ensure that you have
+a `~/.gradle/gradle.properties` with the values for `asfNexusUsername` and `asfNexusPassword` filled in.
+
+```
+asfNexusUsername: mrapache
+asfNexusPassword: apache4life
+```
+
+Then you can simply run `gradlew publish` to build and publish your changes.
+
+### Pushing Releases
+
 Initial support for publishing to a local Maven repository has been added.
 Use the following to do the publish.
 

--- a/build.gradle
+++ b/build.gradle
@@ -19,10 +19,6 @@ under the License.
  
 apply from: 'gradle/wrapper.gradle'
 apply from: 'gradle/other.gradle'
-
-import org.gradle.plugins.signing.Sign
-import java.io.Console
- 
 /* Configure root project */
 allprojects {
   apply plugin: 'idea'
@@ -31,7 +27,7 @@ allprojects {
   repositories {
     mavenCentral()
   }
-  
+
   project.version = build_version
 }
 
@@ -114,10 +110,15 @@ ext {
   COPYRIGHT_YEAR = String.format('%tY', now)
   
   snapshotId = "-SNAPSHOT-${DSTAMP}-${TSTAMP}"
+  publish_url = release_pub_url
   if (System.properties['edgent.snapshotId'] != null) {
     snapshotId = System.properties['edgent.snapshotId']
   }
-                   
+
+  if (System.properties['snapshot'] != null || System.properties['edgent.snapshotId'] != null) {
+    publish_url = snapshot_pub_url
+  }
+
   external_jars_dir = "$rootProject.projectDir/externalJars/java8"
   
   target_dir = "$distsDir"
@@ -693,8 +694,13 @@ subprojects {
       publications {
         mavenJava(MavenPublication) {
           // specify dependencies like: org.apache.edgent:edgent.api.topology:0.4.0
-          groupId = build_group
-          artifactId = "${project.group}.${project.name}" 
+          maven_version = build_version
+          if(System.properties['snapshot'] != null && !build_version.endsWith("-SNAPSHOT")) {
+            maven_version += "-SNAPSHOT"
+          }
+          groupId build_group
+          artifactId "${project.group}.${project.name}"
+          version maven_version
           artifact sourceJar
           if (project.pluginManager.hasPlugin('war')) {
             from components.web
@@ -702,6 +708,15 @@ subprojects {
           else {
             from components.java
           }
+        }
+      }
+      repositories {
+        maven {
+          credentials {
+            username asfNexusUsername ?: ""
+            password asfNexusPassword ?: ""
+          }
+          url publish_url
         }
       }
     }
@@ -821,7 +836,7 @@ task srcReleaseTarGz(type: Tar) {
 gradle.taskGraph.whenReady { taskGraph ->
     if (ext."signing.password"==null && taskGraph.allTasks.any { it instanceof Sign }) {
         // Use Java console to read from the console (no good for a CI environment)
-        def Console console = System.console()
+        def java.io.Console console = System.console()
         console.printf "\n\n#####################################" +
                        "\nWe have to sign some things in this build." +
                        "\nPlease enter your signing details.\n\n"

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,7 +18,10 @@
 build_group: org.apache.edgent
 build_name: edgent
 build_version: 1.2.0
+maven_version: build_version
 build_vendor: Apache Software Foundation
+release_pub_url: https://repository.apache.org/service/local/staging/deploy/maven2
+snapshot_pub_url: https://repository.apache.org/content/repositories/snapshots
 
 # Minimum required gradle version and version for the wrapper to use.
 # Comment out gradleDistributionSha256Sum to disable validation of


### PR DESCRIPTION
This is the first step for EDGENT-413.  The publishing support was mostly there, this adds references to the ASF managed username/password and snapshot URL, if we choose snapshots.  When doing a release you can now publish and it will create a staging repo.

To setup staging, you would need to create `~/.gradle/gradle.properties` and add `asfNexusUsername` and `asfNexusPassword` as properties, pointing to your ASF credentials.