### PR TITLE
[Edgent-424] Cleanup things maven-javadoc-plugin 2.10.4 complains about

### DIFF
--- a/analytics/math3/src/main/java/org/apache/edgent/analytics/math3/Aggregations.java
+++ b/analytics/math3/src/main/java/org/apache/edgent/analytics/math3/Aggregations.java
@@ -60,12 +60,12 @@ import org.apache.edgent.topology.TWindow;
  *  double getTemp() {...};
  *  double getPressure() {...};
  *  ... };
- *TStream&lt;SensorReading> readings = ...
- *TWindow&lt;SensorReading,Integer> window = sensorReadings.last(5, Functions.unpartitioned());
- *TStream&lt;MvResultMap> aggregations = window.batch(
- *      (list, partition) -> {
- *        ResultMap pressureResults = Aggregations.aggregateN(list, t -> t.getPressure(), Statistic2.MEAN, Regression2.SLOPE));
- *        ResultMap tempResults = Aggregations.aggregateN(list, t -> t.getTemp(), Statistic2.MAX));
+ *TStream&lt;SensorReading&gt; readings = ...
+ *TWindow&lt;SensorReading,Integer&gt; window = sensorReadings.last(5, Functions.unpartitioned());
+ *TStream&lt;MvResultMap&gt; aggregations = window.batch(
+ *      (list, partition) -&gt; {
+ *        ResultMap pressureResults = Aggregations.aggregateN(list, t -&gt; t.getPressure(), Statistic2.MEAN, Regression2.SLOPE));
+ *        ResultMap tempResults = Aggregations.aggregateN(list, t -&gt; t.getTemp(), Statistic2.MAX));
  *        MvResultMap results = Aggregations.newMvResults();
  *        results.put("pressure", pressureResults);
  *        results.put("temp", tempResults);
@@ -98,7 +98,7 @@ import org.apache.edgent.topology.TWindow;
  * <p>As a result, using JsonAnalytics for simple cases can be a bit unintuitive and cumbersome.  
  * 
  * <p>For example, to JsonAnalytics for a simple case of a continuous aggregation
- * of {@code TStream<Double>} => {@code TStream<Double>} of MEAN values:
+ * of {@code TStream<Double>} =&gt; {@code TStream<Double>} of MEAN values:
  * 
  * <pre>{@code
  *  TStream<Double> pressureReadings = ...

--- a/analytics/math3/src/main/java/org/apache/edgent/analytics/math3/json/JsonAnalytics.java
+++ b/analytics/math3/src/main/java/org/apache/edgent/analytics/math3/json/JsonAnalytics.java
@@ -253,7 +253,7 @@ public class JsonAnalytics {
      * @param resultPartitionKeyProperty name of the partition key property in the result
      * @param resultProperty name of the aggregation results property in the result
      * @param aggregateSpecs see {@link #mkAggregationSpec(String, JsonUnivariateAggregate...) mkAggregationSpec()}
-     * @return TStream<JsonObject> with aggregation results
+     * @return TStream&lt;JsonObject&gt; with aggregation results
      * 
      * @see #mvAggregateList(String, String, List) mvAggregateList()
      * @see #mkAggregationSpec(String, JsonUnivariateAggregate...) mkAggregationSpec()

--- a/api/execution/src/main/java/org/apache/edgent/execution/mbeans/PeriodMXBean.java
+++ b/api/execution/src/main/java/org/apache/edgent/execution/mbeans/PeriodMXBean.java
@@ -31,7 +31,7 @@ import java.util.concurrent.TimeUnit;
  * {@link org.apache.edgent.execution.services.ControlService ControlService}.
  * </P>
  * 
- * @see org.apache.edgent.topology.Topology#poll(org.apache.edgent.function.Supplier, long, TimeUnit)
+ * See {@code org.apache.edgent.topology.Topology.poll(org.apache.edgent.function.Supplier, long, TimeUnit)}
  */
 public interface PeriodMXBean {
     

--- a/api/execution/src/main/java/org/apache/edgent/execution/services/ControlService.java
+++ b/api/execution/src/main/java/org/apache/edgent/execution/services/ControlService.java
@@ -30,7 +30,7 @@ package org.apache.edgent.execution.services;
  * <P>
  * Different implementations of the control service provide the mechanism
  * to execute methods of the control interfaces. For example
- * {@link org.apache.edgent.runtime.jmxcontrol.JMXControlService JMXControlService}
+ * {@code JMXControlService}
  * registers the MBeans in the JMX platform MBean server.
  * <BR>
  * The control service is intended to allow remote execution of a control interface

--- a/api/topology/src/main/java/org/apache/edgent/topology/TWindow.java
+++ b/api/topology/src/main/java/org/apache/edgent/topology/TWindow.java
@@ -64,7 +64,6 @@ public interface TWindow<T, K> extends TopologyElement {
      * empty if the eviction results in an empty partition.</LI>
      * </UL>
      * A non-null {@code aggregator} result is added to the returned stream.
-     * </P>
      * <P>
      * Thus the returned stream will contain a sequence of tuples where the
      * most recent tuple represents the most up to date aggregation of a
@@ -93,7 +92,6 @@ public interface TWindow<T, K> extends TopologyElement {
      * </UL>
      * A non-null {@code batcher} result is added to the returned stream.
      * The partition's contents are cleared after a batch is processed.
-     * </P>
      * <P>
      * Thus the returned stream will contain a sequence of tuples where the
      * most recent tuple represents the most up to date aggregation of a

--- a/api/topology/src/main/java/org/apache/edgent/topology/json/JsonFunctions.java
+++ b/api/topology/src/main/java/org/apache/edgent/topology/json/JsonFunctions.java
@@ -101,6 +101,7 @@ public class JsonFunctions {
      * <p>Returns a Function whose {@code apply(T v)} returns a JsonObject having 
      * a single property named {@code propName} with the value of {@code v}.
      * 
+     * @param <T> type of number
      * @param propName property name
      * @return the Function
      */

--- a/api/topology/src/main/java/org/apache/edgent/topology/mbeans/package-info.java
+++ b/api/topology/src/main/java/org/apache/edgent/topology/mbeans/package-info.java
@@ -18,6 +18,10 @@ under the License.
 */
 /**
  * Controls for executing topologies.
+ * <P>
+ * The "Attribute Name" column values below correspond to {@code KEY} values defined
+ * in {@code org.apache.edgent.runtime.jsoncontrol.JsonControlService}.
+ * 
  * <h3>Application Service </h3>
  * {@linkplain org.apache.edgent.topology.services.ApplicationService Application service}
  * allows an application to be registered
@@ -39,26 +43,26 @@ under the License.
  *    <th id="desc" align=center><b>Description</b></th>
  *  </tr>
  * <tr>
- *    <td headers="attrName">{@link org.apache.edgent.runtime.jsoncontrol.JsonControlService#TYPE_KEY type}</td>
+ *    <td headers="attrName">{@code type}</td>
  *    <td headers="type">String</td>
  *    <td headers="value">{@link org.apache.edgent.topology.mbeans.ApplicationServiceMXBean#TYPE appService}</td>
  *    <td headers="desc">{@code ApplicationServiceMXBean} control MBean type.</td>
  *  </tr>
  *  <tr>
- *    <td headers="attrName">{@link org.apache.edgent.runtime.jsoncontrol.JsonControlService#OP_KEY op}</td>
+ *    <td headers="attrName">{@code op}</td>
  *    <td headers="type">String</td>
  *    <td headers="value">{@code submit}</td>
  *    <td headers="desc">Invoke {@link org.apache.edgent.topology.mbeans.ApplicationServiceMXBean#submit(String, String) submit} operation
  *    against the control MBean.</td>
  *  </tr>
  *  <tr>
- *    <td headers="attrName">{@link org.apache.edgent.runtime.jsoncontrol.JsonControlService#ALIAS_KEY alias}</td>
+ *    <td headers="attrName">{@code alias}</td>
  *    <td headers="type">String</td>
  *    <td headers="value">Alias of control MBean.</td>
  *    <td headers="desc">Default is {@link org.apache.edgent.topology.services.ApplicationService#ALIAS edgent}.</td>
  *  </tr>
  *  <tr>
- *    <td rowspan="2" headers="attrName">{@link org.apache.edgent.runtime.jsoncontrol.JsonControlService#ARGS_KEY args}</td>
+ *    <td rowspan="2" headers="attrName">{@code args}</td>
  *    <td rowspan="2" headers="type">List</td>
  *    <td headers="value">String: application name</td>
  *    <td headers="desc">Registered application to submit.</td>

--- a/api/topology/src/main/java/org/apache/edgent/topology/plumbing/PlumbingStreams.java
+++ b/api/topology/src/main/java/org/apache/edgent/topology/plumbing/PlumbingStreams.java
@@ -557,7 +557,7 @@ public class PlumbingStreams {
      * }</pre>
      * <P>
      * Note, this implementation requires that the splitter is used from
-     * only a single JVM.  The {@link org.apache.edgent.providers.direct.DirectProvider DirectProvider}
+     * only a single JVM.  The {@code org.apache.edgent.providers.direct.DirectProvider}
      * provider meets this requirement.
      * </P>
      * 

--- a/connectors/command/src/main/java/org/apache/edgent/connectors/command/runtime/ProcessReader.java
+++ b/connectors/command/src/main/java/org/apache/edgent/connectors/command/runtime/ProcessReader.java
@@ -30,8 +30,8 @@ import org.apache.edgent.function.Supplier;
 /**
  * A {@code Supplier<Iterable<String>>} for ingesting a process's output.
  * <P>
- * The iterator returned by {@link Iterable#iterator()) returns
- * {@hasNext()==true} until a read from {@link Process#getInputStream()}
+ * The iterator returned by {@link Iterable#iterator()} returns
+ * {@code hasNext()==true} until a read from {@link Process#getInputStream()}
  * returns EOF or an IOError.
  */
 class ProcessReader implements Supplier<Iterable<String>> {

--- a/connectors/iot/src/main/java/org/apache/edgent/connectors/iot/Commands.java
+++ b/connectors/iot/src/main/java/org/apache/edgent/connectors/iot/Commands.java
@@ -30,12 +30,12 @@ public interface Commands {
      * <BR>
      * The command payload is used to invoke operations
      * against control MBeans using an instance of
-     * {@link org.apache.edgent.runtime.jsoncontrol.JsonControlService}.
+     * {@code org.apache.edgent.runtime.jsoncontrol.JsonControlService}.
      * <BR>
      * Value is {@value}.
      * 
      * @see org.apache.edgent.execution.services.ControlService
-     * @see org.apache.edgent.providers.iot.IotProvider
+     * See {@code org.apache.edgent.providers.iot.IotProvider}
      */
     String CONTROL_SERVICE = IotDevice.RESERVED_ID_PREFIX + "Control";
 

--- a/connectors/iotp/src/main/java/org/apache/edgent/connectors/iotp/IotpDevice.java
+++ b/connectors/iotp/src/main/java/org/apache/edgent/connectors/iotp/IotpDevice.java
@@ -51,7 +51,7 @@ import com.ibm.iotf.client.device.DeviceClient;
  * scale message hub that provides a device model on top of MQTT.
  * {@code IotpDevice} implements the generic device model {@link IotDevice}
  * and thus can be used as a connector for
- * {@link org.apache.edgent.providers.iot.IotProvider}.
+ * {@code org.apache.edgent.providers.iot.IotProvider}.
  * <BR>
  * <em>Note IBM Watson IoT Platform was previously known as
  * IBM Internet of Things Foundation.</em>
@@ -81,8 +81,9 @@ import com.ibm.iotf.client.device.DeviceClient;
  * for details of changes that occurred to device event payloads
  * and how to revert the behavior if needed.
  * <p>
- * @see <a href="{@docRoot}/org/apache/edgent/connectors/iot/package-summary.html">Edgent generic device model</a>
- * @see org.apache.edgent.samples.connectors.iotp.IotpSensors Sample application
+ * See <a href="{@docRoot}/org/apache/edgent/connectors/iot/package-summary.html">Edgent generic device model</a>
+ * <p>
+ * See {@code org.apache.edgent.samples.connectors.iotp.IotpSensors} Sample application
  */
 public class IotpDevice implements IotDevice {
     
@@ -199,7 +200,7 @@ public class IotpDevice implements IotDevice {
      * @return Connector to the Quickstart service.
      * 
      * @see <a href="https://quickstart.internetofthings.ibmcloud.com">Quickstart</a>
-     * @see org.apache.edgent.samples.connectors.iotp.IotpQuickstart Quickstart sample application
+     * See {@code org.apache.edgent.samples.connectors.iotp.IotpQuickstart Quickstart} sample application
      */
     public static IotpDevice quickstart(Topology topology, String deviceId) {
         Properties options = new Properties();

--- a/connectors/mqtt/src/test/java/org/apache/edgent/test/connectors/mqtt/MqttOpenTest.java
+++ b/connectors/mqtt/src/test/java/org/apache/edgent/test/connectors/mqtt/MqttOpenTest.java
@@ -32,7 +32,7 @@ import org.junit.rules.TestName;
 /**
  * Uses the MQTT test broker at: tcp://test.mosquitto.org:1883
  * 
- * @see <a href="http://test.mosquitto.org/">http://test.mosquitto.org/</a>
+ * See <a href="http://test.mosquitto.org/">http://test.mosquitto.org/</a>
  * 
  * The tests are skipped if unable to connect (e.g., due to firewall config,
  * or the public broker not available for whatever reason).

--- a/providers/iot/src/main/java/org/apache/edgent/providers/iot/IotProvider.java
+++ b/providers/iot/src/main/java/org/apache/edgent/providers/iot/IotProvider.java
@@ -64,8 +64,8 @@ import com.google.gson.JsonObject;
  * class MyApp {
  *   ...
  *   public void run(String[] args) throws Exception {
- *      IotProvider provider = new IotProvider((top) -> new IotpDevice(top, myDeviceConfig));
- *      provider.registerTopology("app1", (iotDevice, cfg) -> buildApp1(iotDevice, cfg));
+ *      IotProvider provider = new IotProvider((top) -&gt; new IotpDevice(top, myDeviceConfig));
+ *      provider.registerTopology("app1", (iotDevice, cfg) -&gt; buildApp1(iotDevice, cfg));
  *      provider.start();
  *   }
  *   private void buildApp1(IotDevice iotDevice, JsonConfig cfg) {

--- a/utils/streamscope/src/main/java/org/apache/edgent/streamscope/StreamScope.java
+++ b/utils/streamscope/src/main/java/org/apache/edgent/streamscope/StreamScope.java
@@ -50,7 +50,7 @@ import org.apache.edgent.streamscope.mbeans.StreamScopeRegistryMXBean;
  * and {@link StreamScopeRegistryMXBean} runtime ControlService.
  * </P>
  * @see StreamScopeRegistry
- * @see org.apache.edgent.providers.development.DevelopmentProvider DevelopmentProvider
+ * See {@code org.apache.edgent.providers.development.DevelopmentProvider}
  * 
  * @param <T> Tuple type
  */

--- a/utils/streamscope/src/main/java/org/apache/edgent/streamscope/StreamScopeRegistry.java
+++ b/utils/streamscope/src/main/java/org/apache/edgent/streamscope/StreamScopeRegistry.java
@@ -37,7 +37,7 @@ import java.util.Set;
  * Static methods are provided for composing these names and extracting
  * the alias/identifier from generated names.
  * </P>
- * @see org.apache.edgent.providers.development.DevelopmentProvider DevelopmentProvider
+ * See {@code org.apache.edgent.providers.development.DevelopmentProvider}
  */
 public class StreamScopeRegistry {
   private final Map<String, StreamScope<?>> byNameMap = new HashMap<>();

--- a/utils/streamscope/src/main/java/org/apache/edgent/streamscope/mbeans/StreamScopeRegistryMXBean.java
+++ b/utils/streamscope/src/main/java/org/apache/edgent/streamscope/mbeans/StreamScopeRegistryMXBean.java
@@ -24,7 +24,7 @@ package org.apache.edgent.streamscope.mbeans;
  * The registry contains a collection of StreamScopeMXBean instances
  * that are registered by a stream identifier.
  * </P>
- * @see org.apache.edgent.providers.development.DevelopmentProvider DevelopmentProvider
+ * See {@code org.apache.edgent.providers.development.DevelopmentProvider}
  */
 public interface StreamScopeRegistryMXBean {
   


### PR DESCRIPTION
Seen when failOnError is enabled
- remove cross project links to non-dependent projects
- remove anchor refs from @see
- replace problem '>' with &gt;
- remove problem </P>