### PR TITLE
[EDGENT-448] add a new ignore item to filter .DS_Store for mac os x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ hs_err_pid*
 
 # Emacs
 *~
+
+# Mac os x
+*.DS_Store


### PR DESCRIPTION
## What is the purpose of the change

This PR adds a new ignore item to filter .DS_Store for mac os x.

## Brief change log

  - *Add a new ignore item to filter .DS_Store for mac os x*

## Verifying this change

This change is trivial and no test case to verify.

## Does this pull request potentially affect one of the following parts: NO

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not documented)
